### PR TITLE
--title

### DIFF
--- a/templates/settings.json
+++ b/templates/settings.json
@@ -1,10 +1,6 @@
 {
   "permissions": {
-    "allow": [
-      "Bash(npm *)", "Bash(npx *)", "Bash(git *)", "Bash(ls *)",
-      "Bash(mkdir *)", "Bash(node *)", "Bash(tsc *)", "Bash(jq *)",
-      "Read", "Edit", "Write", "Glob", "Grep"
-    ],
+    "defaultMode": "bypassPermissions",
     "deny": [
       "Bash(rm -rf /)", "Bash(rm -rf ~)", "Bash(sudo *)",
       "Read(.env*)", "Read(**/credentials*)", "Read(**/*secret*)"
@@ -22,33 +18,7 @@
         ]
       }
     ],
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash .claude/hooks/check-careful.sh",
-            "timeout": 5000
-          },
-          {
-            "type": "command",
-            "command": "bash .claude/hooks/check-safety.sh",
-            "timeout": 5000
-          }
-        ]
-      },
-      {
-        "matcher": "Agent",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash .claude/hooks/check-gate-isolation.sh",
-            "timeout": 5000
-          }
-        ]
-      }
-    ],
+    "PreToolUse": [],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",


### PR DESCRIPTION
## 변경 사항

677a4e2 fix: PreToolUse Bash 훅 제거로 자율 실행 마비 회귀 해소 (#2)

```
 1 file changed, 2 insertions(+), 32 deletions(-)
```

Closes #2

---
🤖 Generated by Claude Code [claude-opus-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated permission system configuration to operate in bypass mode while maintaining security restrictions for destructive and sensitive operations
  * Removed pre-execution validation checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->