### PR TITLE
--title

### DIFF
--- a/docs/plans/v8-backlog.md
+++ b/docs/plans/v8-backlog.md
@@ -64,17 +64,18 @@ v7.1 의 `defaultMode: bypassPermissions` + narrow deny-list 는 무마찰 자�
 
 **증거**: 
 - `docs/research/2026-04-11-tsb-harness-architect.md` §A.3 — "trading-signal-bot 은 `vercel --prod`, `vercel env rm`, `redis-cli FLUSHDB` 가 전부 허용됨. audit trail 없음."
-- `skills/start-company/HARNESS-GUIDE.md:196` — "Retained for future exit-0 advisory rewrite"
+- `skills/start-company/HARNESS-GUIDE.md` v7.1 Runtime Safety 섹션 — "Retained for future exit-0 advisory rewrite"
 
-**스케치**:
-- `templates/hooks/check-audit.sh` (가칭) — PreToolUse Bash 훅, **절대 exit non-zero 안 함**
-- 매 커맨드 + timestamp + session id 를 `.omc/audit/YYYY-MM-DD.jsonl` 에 append
-- 패턴 매칭으로 `CAREFUL` 태그 (예: `vercel --prod`, `npm install`, `redis-cli FLUSH*`) — 차단 아님, 로깅만
-- 별도 리뷰어 에이전트가 post-session 에 audit log 읽고 suspicious sequence 플래그
+**구현** (2026-04-11, issue #4):
+- `templates/hooks/check-audit.sh` — PreToolUse Bash 훅. `trap 'exit 0' ERR EXIT` + 모든 외부 호출에 fallback + 명시적 `exit 0`. **exit non-zero 경로 없음**.
+- `.claude/audit/YYYY-MM-DD.jsonl` 에 `{ts, session, matcher, tags, cmd}` JSONL append
+- CAREFUL 패턴 태그 (라벨만, 차단 아님): `deploy` (vercel --prod/env), `redis-flush` (FLUSHDB/FLUSHALL), `npm-install`, `git-destructive` (force push/hard reset), `rm-rf`
+- `templates/settings.json` 의 PreToolUse Bash matcher 에 등록 (timeout 3000ms)
+- `HARNESS-GUIDE.md` Runtime Safety 섹션에 v8.1.1 블록 추가, v7 blocking 훅과의 대비 명시 (재발 방지)
 
-**의존성**: 없음. 독립적으로 구현 가능.
+**의존성**: 없음. 독립적으로 완결. 1.4 (post-session 리뷰어) unblock.
 **첫 검증 사이트 후보**: trading-signal-bot (연동 계획은 `docs/field-reports/2026-04-11-tsb-contribution-plan.md` Phase E)
-**상태**: `todo`
+**상태**: `in-progress` (PR #5, 2026-04-11. 머지 시 `done` 로 업데이트 예정)
 
 ### 1.2 Write-time secret leakage scanner [MED / Small]
 

--- a/docs/plans/v8-backlog.md
+++ b/docs/plans/v8-backlog.md
@@ -64,7 +64,7 @@ v7.1 의 `defaultMode: bypassPermissions` + narrow deny-list 는 무마찰 자�
 
 **증거**: 
 - `docs/research/2026-04-11-tsb-harness-architect.md` §A.3 — "trading-signal-bot 은 `vercel --prod`, `vercel env rm`, `redis-cli FLUSHDB` 가 전부 허용됨. audit trail 없음."
-- `skills/start-company/HARNESS-GUIDE.md` v7.1 Runtime Safety 섹션 — "Retained for future exit-0 advisory rewrite"
+- `skills/start-company/HARNESS-GUIDE.md` "Design Decision: Runtime Safety via deny-list (v7.1 revision)" 섹션 — v7.1 이 exit-0 advisory 훅을 future work 로 명시적으로 미룬 기록. v7 릴리스 커밋 `e61f0af` 와 v7.1 hotfix 커밋 `546f24c` 참조.
 
 **구현** (2026-04-11, issue #4):
 - `templates/hooks/check-audit.sh` — PreToolUse Bash 훅. `trap 'exit 0' ERR EXIT` + 모든 외부 호출에 fallback + 명시적 `exit 0`. **exit non-zero 경로 없음**.

--- a/skills/start-company/HARNESS-GUIDE.md
+++ b/skills/start-company/HARNESS-GUIDE.md
@@ -196,12 +196,37 @@ leaving the long tail of "risky but sometimes legitimate" ops (force push, `--ha
 reset, etc.) to CLAUDE.md rules and code review. Those latter cases are recoverable via
 git reflog / PR revert; the deny-list targets only the strictly unrecoverable.
 
-### The future: exit-0 advisory hooks (out of scope for v7.1)
+### v8.1.1: exit-0 audit log (landed, 2026-04-11)
 
-The right home for S01-S08-style pattern detection is a **logging-only** PreToolUse
-hook that always exits 0, writes observations to a log file, and never halts the loop.
-`check-careful.sh` is retained in `templates/hooks/` for this future rewrite. Tracked
-separately — not part of the v7.1 hotfix.
+The logging-only complement to the deny-list — first promised as "out of scope for
+v7.1", now shipped as v8 backlog item 1.1.
+
+`templates/hooks/check-audit.sh` runs on every Bash command via PreToolUse matcher.
+Its design invariant is **"must always exit 0"**: `trap 'exit 0' ERR EXIT`, every
+external call has a fallback, explicit `exit 0` at the bottom. Cannot cause the v7
+regression because it has no code path that returns non-zero.
+
+What it does:
+- Append `{ts, session, matcher, tags, cmd}` to `.claude/audit/YYYY-MM-DD.jsonl`
+- Tag suspicious patterns (label only, not block): `deploy` (vercel --prod, env add/rm),
+  `redis-flush` (FLUSHDB/FLUSHALL), `npm-install`, `git-destructive` (force push,
+  --hard reset), `rm-rf`
+- Stay silent on all failures — a failed audit log is preferable to a stalled loop
+
+What it is NOT:
+- Not a replacement for `permissions.deny`. Things that must never happen
+  (rm -rf /, sudo, secret reads) still live there.
+- Not a blocker. An agent running `vercel --prod` gets tagged `CAREFUL deploy`
+  but the command still runs. Enforcement is the deny-list's job.
+
+Downstream projects that care about post-session review (trading bots, payment
+services, deploy-sensitive repos) can add `.claude/audit/` to `.gitignore` and
+grep the JSONL files when a session misbehaves. A future item (v8 1.4) adds a
+post-session auditor agent to surface suspicious sequences automatically.
+
+Complementary pattern: `check-careful.sh` is retained in `templates/hooks/` for
+possible future use as a more specialized logging variant. It is currently
+unwired — the v8.1.1 `check-audit.sh` is the sole PreToolUse Bash hook.
 
 ---
 

--- a/skills/start-company/HARNESS-GUIDE.md
+++ b/skills/start-company/HARNESS-GUIDE.md
@@ -216,8 +216,11 @@ What it does:
 What it is NOT:
 - Not a replacement for `permissions.deny`. Things that must never happen
   (rm -rf /, sudo, secret reads) still live there.
-- Not a blocker. An agent running `vercel --prod` gets tagged `CAREFUL deploy`
-  but the command still runs. Enforcement is the deny-list's job.
+- Not a blocker. An agent running `vercel --prod` gets the literal string
+  `deploy` appended to the JSONL entry's `tags` field — the command still runs.
+  Auditors grep the `tags` field (there is no literal `CAREFUL` prefix in
+  the log; "CAREFUL" is just a conceptual shorthand for "any tagged command").
+  Enforcement is the deny-list's job, not the audit log's.
 
 Downstream projects that care about post-session review (trading bots, payment
 services, deploy-sensitive repos) can add `.claude/audit/` to `.gitignore` and

--- a/templates/hooks/check-audit.sh
+++ b/templates/hooks/check-audit.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# check-audit.sh — Exit-0 audit log for PreToolUse Bash matcher
+#
+# idea-factory v8 item 1.1 (docs/plans/v8-backlog.md Theme 1)
+# First implementation of the "exit-0 advisory hook" future work that
+# HARNESS-GUIDE.md v7.1 Runtime Safety section shelved.
+#
+# ─────────────────────────────────────────────────────────────────────
+# PURPOSE
+# ─────────────────────────────────────────────────────────────────────
+# Log every Bash command Claude Code executes into
+# .claude/audit/YYYY-MM-DD.jsonl for post-session review.
+# Tag suspicious patterns with CAREFUL labels (deploy, redis-flush,
+# npm-install, git-destructive, rm-rf) so an auditor can grep them.
+#
+# ─────────────────────────────────────────────────────────────────────
+# CRITICAL INVARIANT: THIS SCRIPT MUST ALWAYS EXIT 0
+# ─────────────────────────────────────────────────────────────────────
+# v7 regression (2026-04) was caused by blocking PreToolUse hooks
+# (check-careful.sh, check-safety.sh) that returned non-zero on risky
+# commands, which Claude Code interpreted as "ask user to approve".
+# Every Bash command in downstream projects then required manual
+# approval, paralyzing autonomous loops. See:
+#   docs/field-reports/2026-04-11-v7-propagation-postmortem.md
+#
+# This script complements the v7.1 deny-list (which catches strictly
+# unrecoverable operations) by OBSERVING without HALTING. Any Bash
+# command that would be blocked belongs in permissions.deny in
+# settings.json, not here.
+#
+# The exit-0 guarantee is enforced by:
+#   1. `trap 'exit 0' ERR EXIT` at the top
+#   2. Every external command tolerates failure with `|| true` or
+#      `2>/dev/null || ...`
+#   3. Explicit `exit 0` at the bottom
+#   4. Fallbacks for every value we extract (date, jq, grep, etc.)
+#
+# If you are editing this script and about to add `exit 1`, `return 1`,
+# `set -e`, or anything that could cause non-zero exit: DO NOT.
+# Wrap your new logic in `{ ... } 2>/dev/null || true` instead.
+
+trap 'exit 0' ERR EXIT
+
+{
+  # ── Configuration ──────────────────────────────────────────────
+  AUDIT_DIR="${CLAUDE_AUDIT_DIR:-.claude/audit}"
+  MAX_CMD_LEN=2048
+
+  # Create directory, silently tolerate failure
+  mkdir -p "$AUDIT_DIR" 2>/dev/null || true
+
+  # Date helpers with fallbacks
+  TODAY=$(date +%Y-%m-%d 2>/dev/null)
+  [ -z "$TODAY" ] && TODAY="unknown-date"
+
+  NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)
+  [ -z "$NOW" ] && NOW="unknown-time"
+
+  LOG_FILE="$AUDIT_DIR/$TODAY.jsonl"
+
+  # ── Read hook payload from stdin ───────────────────────────────
+  # Claude Code PreToolUse hooks receive a JSON payload on stdin
+  # including tool_name, tool_input (Bash: .command), and metadata.
+  # Parse defensively — never trust format.
+  PAYLOAD=""
+  if [ -p /dev/stdin ] || [ ! -t 0 ]; then
+    PAYLOAD=$(cat 2>/dev/null || echo '')
+  fi
+  [ -z "$PAYLOAD" ] && PAYLOAD='{}'
+
+  # Extract Bash command (best-effort grep; no jq dependency)
+  # Matches: "command": "something" or "command":"something"
+  CMD=$(printf '%s' "$PAYLOAD" \
+    | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' 2>/dev/null \
+    | head -1 \
+    | sed 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/' 2>/dev/null)
+  [ -z "$CMD" ] && CMD=""
+
+  # Truncate extremely long commands
+  CMD_LEN=${#CMD}
+  if [ "$CMD_LEN" -gt "$MAX_CMD_LEN" ] 2>/dev/null; then
+    CMD=$(printf '%s' "$CMD" | cut -c1-$MAX_CMD_LEN 2>/dev/null)
+    CMD="${CMD}...[truncated]"
+  fi
+
+  # ── Pattern-based CAREFUL tagging (label only, NEVER block) ────
+  TAGS=""
+  if printf '%s' "$CMD" | grep -qE "vercel[[:space:]]+(--prod|env[[:space:]]+(add|rm))" 2>/dev/null; then
+    TAGS="$TAGS deploy"
+  fi
+  if printf '%s' "$CMD" | grep -qE "redis-cli[[:space:]]+(FLUSHDB|FLUSHALL)" 2>/dev/null; then
+    TAGS="$TAGS redis-flush"
+  fi
+  if printf '%s' "$CMD" | grep -qE "npm[[:space:]]+install[[:space:]]+[^-]" 2>/dev/null; then
+    TAGS="$TAGS npm-install"
+  fi
+  if printf '%s' "$CMD" | grep -qE "git[[:space:]]+push.*--force|git[[:space:]]+reset.*--hard" 2>/dev/null; then
+    TAGS="$TAGS git-destructive"
+  fi
+  if printf '%s' "$CMD" | grep -qE "rm[[:space:]]+-[a-zA-Z]*r[a-zA-Z]*f|rm[[:space:]]+-[a-zA-Z]*f[a-zA-Z]*r" 2>/dev/null; then
+    TAGS="$TAGS rm-rf"
+  fi
+  # Trim leading space
+  TAGS="${TAGS# }"
+
+  # ── Session metadata ───────────────────────────────────────────
+  SESSION_ID="${CLAUDE_SESSION_ID:-unknown}"
+
+  # ── Minimal JSON escape for the command string ────────────────
+  # Escape: backslash → \\, double-quote → \", control chars → space
+  ESCAPED_CMD=$(printf '%s' "$CMD" \
+    | sed 's/\\/\\\\/g; s/"/\\"/g' 2>/dev/null \
+    | tr -d '\n\r\t' 2>/dev/null)
+
+  # ── Compose JSONL entry ────────────────────────────────────────
+  ENTRY=$(printf '{"ts":"%s","session":"%s","matcher":"Bash","tags":"%s","cmd":"%s"}' \
+    "$NOW" "$SESSION_ID" "$TAGS" "$ESCAPED_CMD" 2>/dev/null)
+
+  # ── Append to log, silently tolerate all failures ──────────────
+  if [ -n "$ENTRY" ]; then
+    printf '%s\n' "$ENTRY" >> "$LOG_FILE" 2>/dev/null || true
+  fi
+
+} 2>/dev/null
+
+# Explicit exit 0 — the most important line in this script.
+exit 0

--- a/templates/hooks/check-audit.sh
+++ b/templates/hooks/check-audit.sh
@@ -49,6 +49,15 @@ trap 'exit 0' ERR EXIT
   # Create directory, silently tolerate failure
   mkdir -p "$AUDIT_DIR" 2>/dev/null || true
 
+  # Ensure audit logs are NEVER committed — drop a local .gitignore on first run.
+  # Defense-in-depth: even if the parent repo doesn't gitignore .claude/audit/,
+  # this local .gitignore makes everything in this directory untracked.
+  # Rationale: shell commands (and thus audit logs) can contain secrets in args.
+  GITIGNORE_FILE="$AUDIT_DIR/.gitignore"
+  if [ ! -f "$GITIGNORE_FILE" ] 2>/dev/null; then
+    printf '*\n!.gitignore\n' > "$GITIGNORE_FILE" 2>/dev/null || true
+  fi
+
   # Date helpers with fallbacks
   TODAY=$(date +%Y-%m-%d 2>/dev/null)
   [ -z "$TODAY" ] && TODAY="unknown-date"
@@ -68,12 +77,29 @@ trap 'exit 0' ERR EXIT
   fi
   [ -z "$PAYLOAD" ] && PAYLOAD='{}'
 
-  # Extract Bash command (best-effort grep; no jq dependency)
-  # Matches: "command": "something" or "command":"something"
-  CMD=$(printf '%s' "$PAYLOAD" \
-    | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' 2>/dev/null \
-    | head -1 \
-    | sed 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/' 2>/dev/null)
+  # Extract Bash command — prefer python3 (JSON-aware), grep as fallback.
+  # python3 handles escaped quotes correctly; grep is a safety net only.
+  CMD=""
+  if command -v python3 >/dev/null 2>&1; then
+    CMD=$(printf '%s' "$PAYLOAD" | python3 -c "
+import sys, json
+try:
+    d = json.loads(sys.stdin.read())
+    v = d.get('tool_input', {}).get('command', '')
+    if not isinstance(v, str):
+        v = str(v)
+    sys.stdout.write(v)
+except Exception:
+    pass
+" 2>/dev/null)
+  fi
+  # Fallback: grep-based extraction (may truncate on embedded escaped quotes)
+  if [ -z "$CMD" ]; then
+    CMD=$(printf '%s' "$PAYLOAD" \
+      | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' 2>/dev/null \
+      | head -1 \
+      | sed 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/' 2>/dev/null)
+  fi
   [ -z "$CMD" ] && CMD=""
 
   # Truncate extremely long commands
@@ -83,15 +109,19 @@ trap 'exit 0' ERR EXIT
     CMD="${CMD}...[truncated]"
   fi
 
-  # ── Pattern-based CAREFUL tagging (label only, NEVER block) ────
+  # ── Pattern tagging (label only, NEVER block). Case-insensitive. ──
+  # Tag values written to the `tags` field of the JSONL entry. Auditors
+  # grep these labels — there is no literal "CAREFUL" prefix in the output.
   TAGS=""
-  if printf '%s' "$CMD" | grep -qE "vercel[[:space:]]+(--prod|env[[:space:]]+(add|rm))" 2>/dev/null; then
+  if printf '%s' "$CMD" | grep -qiE "vercel[[:space:]]+(--prod|env[[:space:]]+(add|rm))" 2>/dev/null; then
     TAGS="$TAGS deploy"
   fi
-  if printf '%s' "$CMD" | grep -qE "redis-cli[[:space:]]+(FLUSHDB|FLUSHALL)" 2>/dev/null; then
+  if printf '%s' "$CMD" | grep -qiE "redis-cli[[:space:]]+(flushdb|flushall)" 2>/dev/null; then
     TAGS="$TAGS redis-flush"
   fi
-  if printf '%s' "$CMD" | grep -qE "npm[[:space:]]+install[[:space:]]+[^-]" 2>/dev/null; then
+  # npm install: matches "npm install", "npm install <pkg>", "npm install --flag",
+  # and bare "npm install" at end of command.
+  if printf '%s' "$CMD" | grep -qE "npm[[:space:]]+install([[:space:]]|$)" 2>/dev/null; then
     TAGS="$TAGS npm-install"
   fi
   if printf '%s' "$CMD" | grep -qE "git[[:space:]]+push.*--force|git[[:space:]]+reset.*--hard" 2>/dev/null; then
@@ -106,15 +136,21 @@ trap 'exit 0' ERR EXIT
   # ── Session metadata ───────────────────────────────────────────
   SESSION_ID="${CLAUDE_SESSION_ID:-unknown}"
 
-  # ── Minimal JSON escape for the command string ────────────────
-  # Escape: backslash → \\, double-quote → \", control chars → space
-  ESCAPED_CMD=$(printf '%s' "$CMD" \
-    | sed 's/\\/\\\\/g; s/"/\\"/g' 2>/dev/null \
-    | tr -d '\n\r\t' 2>/dev/null)
+  # ── Minimal JSON escape (applied to EVERY string field) ───────
+  # Escape backslash and double-quote; strip \n \r \t so they don't
+  # break the JSONL format. This MUST be applied to any field that
+  # can contain user/env-controlled data (CMD, SESSION_ID, TAGS).
+  escape_json() {
+    printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g' 2>/dev/null | tr -d '\n\r\t' 2>/dev/null
+  }
+  ESCAPED_CMD=$(escape_json "$CMD")
+  ESCAPED_SESSION=$(escape_json "$SESSION_ID")
+  ESCAPED_TAGS=$(escape_json "$TAGS")
 
   # ── Compose JSONL entry ────────────────────────────────────────
+  # NOW is from `date -u +...` — format is controlled, no escape needed.
   ENTRY=$(printf '{"ts":"%s","session":"%s","matcher":"Bash","tags":"%s","cmd":"%s"}' \
-    "$NOW" "$SESSION_ID" "$TAGS" "$ESCAPED_CMD" 2>/dev/null)
+    "$NOW" "$ESCAPED_SESSION" "$ESCAPED_TAGS" "$ESCAPED_CMD" 2>/dev/null)
 
   # ── Append to log, silently tolerate all failures ──────────────
   if [ -n "$ENTRY" ]; then

--- a/templates/settings.json
+++ b/templates/settings.json
@@ -18,7 +18,18 @@
         ]
       }
     ],
-    "PreToolUse": [],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/check-audit.sh",
+            "timeout": 3000
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",


### PR DESCRIPTION
## 변경 사항

2f3284f feat: v8 item 1.1 — exit-0 audit log PreToolUse hook (#4)

```
 4 files changed, 178 insertions(+), 14 deletions(-)
```

Closes #4

---
🤖 Generated by Claude Code [claude-opus-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added non-blocking pre-execution audit logging for commands with label-only tagging of suspicious patterns (deploy, redis-flush, npm-install, git-destructive, rm-rf) for visibility without blocking execution.

* **Documentation**
  * Updated runtime safety docs to describe the v8.1.1 audit logging behavior, tagging approach, and operational guarantees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->