### PR TITLE
--title

### DIFF
--- a/docs/plans/v8-backlog.md
+++ b/docs/plans/v8-backlog.md
@@ -370,7 +370,7 @@ v7 까지 idea-factory 는 암묵적으로 **"웹앱 + Playwright UI"** 를 가�
 
 **증거**: `docs/research/2026-04-12-ecc-comparison.md` Gap §5 (HIGH — Cost Tracking Hook)
 
-**구현** (2026-04-12, issue #9):
+**구현** (2026-04-11, issue #9):
 - `templates/hooks/stop-cost-summary.sh` — Stop 훅. stdin 으로 받는 hook payload 에서 `transcript_path` 추출, JSONL 파싱해서 input/output/cache_creation/cache_read 토큰 카테고리별 합산
 - `.claude/audit/cost-YYYY-MM-DD.jsonl` 에 한 줄 append: `{ts, session, input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens}`
 - 첫 실행 시 `.claude/audit/.gitignore` 자동 생성
@@ -380,7 +380,7 @@ v7 까지 idea-factory 는 암묵적으로 **"웹앱 + Playwright UI"** 를 가�
 - `tests/hooks/stop-cost-summary.test.sh` — 14개 assertion (정상 합산, 빈 stdin, 누락 path, malformed JSONL, 빈 transcript, gitignore 자동 생성, JSONL 유효성, **shell injection 가드 카나리** 포함)
 
 **의존성**: 없음. 1.1 audit log 와 같은 디렉터리 공유.
-**상태**: `in-progress` (PR #10, 2026-04-12. 머지 시 `done` 로 업데이트)
+**상태**: `in-progress` (PR #10, 2026-04-11. 머지 시 `done` 로 업데이트)
 
 ### 7.3 Config protection hook [HIGH / Small]
 

--- a/docs/plans/v8-backlog.md
+++ b/docs/plans/v8-backlog.md
@@ -370,13 +370,17 @@ v7 까지 idea-factory 는 암묵적으로 **"웹앱 + Playwright UI"** 를 가�
 
 **증거**: `docs/research/2026-04-12-ecc-comparison.md` Gap §5 (HIGH — Cost Tracking Hook)
 
-**스케치**: 
-- `templates/hooks/stop-cost-summary.sh` — Stop 훅. 세션 transcript 또는 agent metrics 읽고 input/output 토큰 + 추정 비용 출력
-- `.claude/audit/cost-YYYY-MM-DD.jsonl` 에 기록 (audit log 와 동일 디렉터리)
-- exit 0 보장
+**구현** (2026-04-12, issue #9):
+- `templates/hooks/stop-cost-summary.sh` — Stop 훅. stdin 으로 받는 hook payload 에서 `transcript_path` 추출, JSONL 파싱해서 input/output/cache_creation/cache_read 토큰 카테고리별 합산
+- `.claude/audit/cost-YYYY-MM-DD.jsonl` 에 한 줄 append: `{ts, session, input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens}`
+- 첫 실행 시 `.claude/audit/.gitignore` 자동 생성
+- 비용 환산은 의도적으로 안 함 (모델별/시점별 가격 변동 → raw 토큰만 영구 기록, 환산은 별도 도구)
+- shell injection 방지: transcript_path 를 env var 로 python3 에 전달 (절대 shell interpolation 안 함)
+- `templates/settings.json` 의 Stop hooks 배열에 등록 (timeout 5000ms, check-quality.sh 와 공존)
+- `tests/hooks/stop-cost-summary.test.sh` — 14개 assertion (정상 합산, 빈 stdin, 누락 path, malformed JSONL, 빈 transcript, gitignore 자동 생성, JSONL 유효성, **shell injection 가드 카나리** 포함)
 
 **의존성**: 없음. 1.1 audit log 와 같은 디렉터리 공유.
-**상태**: `todo`
+**상태**: `in-progress` (PR #10, 2026-04-12. 머지 시 `done` 로 업데이트)
 
 ### 7.3 Config protection hook [HIGH / Small]
 

--- a/templates/hooks/stop-cost-summary.sh
+++ b/templates/hooks/stop-cost-summary.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# stop-cost-summary.sh — Aggregate session token usage at Stop time
+#
+# idea-factory v8 item 7.2 (docs/plans/v8-backlog.md Theme 7)
+# Inspired by ECC's stop:cost-tracker pattern (docs/research/2026-04-12-ecc-comparison.md).
+#
+# ─────────────────────────────────────────────────────────────────────
+# PURPOSE
+# ─────────────────────────────────────────────────────────────────────
+# At session Stop time, read the session transcript and sum tokens by
+# category. Append one JSONL entry to .claude/audit/cost-YYYY-MM-DD.jsonl.
+# CEO can `cat` that file to see the day's cost without reading transcripts.
+#
+# Token categories: input, output, cache_creation_input, cache_read_input.
+# We deliberately do NOT compute dollar cost — model prices vary and
+# change over time. Raw token counts are durable; conversion belongs to
+# a separate report tool.
+#
+# ─────────────────────────────────────────────────────────────────────
+# CRITICAL INVARIANT: THIS SCRIPT MUST ALWAYS EXIT 0
+# ─────────────────────────────────────────────────────────────────────
+# Same rule as check-audit.sh. Stop hooks must never block session
+# completion. If transcript_path is missing, malformed, or empty:
+# log zeros and continue. v7 regression guard (tests/invariant-exit-zero.sh)
+# verifies this on every commit.
+
+trap 'exit 0' ERR EXIT
+
+{
+  # ── Configuration ──────────────────────────────────────────────
+  AUDIT_DIR="${CLAUDE_AUDIT_DIR:-.claude/audit}"
+  mkdir -p "$AUDIT_DIR" 2>/dev/null || true
+
+  # .gitignore protection (defense-in-depth, same pattern as check-audit.sh)
+  # Cost logs may contain session ids which are not secrets but are also
+  # not needed in version control.
+  GITIGNORE_FILE="$AUDIT_DIR/.gitignore"
+  if [ ! -f "$GITIGNORE_FILE" ] 2>/dev/null; then
+    printf '*\n!.gitignore\n' > "$GITIGNORE_FILE" 2>/dev/null || true
+  fi
+
+  # Date helpers with fallbacks
+  TODAY=$(date +%Y-%m-%d 2>/dev/null)
+  [ -z "$TODAY" ] && TODAY="unknown-date"
+
+  NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)
+  [ -z "$NOW" ] && NOW="unknown-time"
+
+  COST_FILE="$AUDIT_DIR/cost-$TODAY.jsonl"
+
+  # ── Read Stop hook payload from stdin ───────────────────────────
+  PAYLOAD=""
+  if [ ! -t 0 ]; then
+    PAYLOAD=$(cat 2>/dev/null || echo '')
+  fi
+  [ -z "$PAYLOAD" ] && PAYLOAD='{}'
+
+  # ── Extract session_id and transcript_path via python3 ─────────
+  # Use python3 for JSON-aware parsing (handles escaped chars).
+  # Pass payload via stdin pipe; never via shell-interpolated string.
+  SESSION_ID="unknown"
+  TRANSCRIPT_PATH=""
+  if command -v python3 >/dev/null 2>&1; then
+    EXTRACTED=$(printf '%s' "$PAYLOAD" | python3 -c "
+import sys, json
+try:
+    d = json.loads(sys.stdin.read())
+    sid = d.get('session_id', 'unknown') or 'unknown'
+    tp = d.get('transcript_path', '') or ''
+    if not isinstance(sid, str): sid = str(sid)
+    if not isinstance(tp, str): tp = str(tp)
+    print(sid)
+    print(tp)
+except Exception:
+    print('unknown')
+    print('')
+" 2>/dev/null)
+    SESSION_ID=$(printf '%s' "$EXTRACTED" | sed -n '1p')
+    TRANSCRIPT_PATH=$(printf '%s' "$EXTRACTED" | sed -n '2p')
+  fi
+  [ -z "$SESSION_ID" ] && SESSION_ID="unknown"
+
+  # ── Sum tokens from transcript JSONL if available ──────────────
+  IN_T=0
+  OUT_T=0
+  CACHE_C=0
+  CACHE_R=0
+
+  if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ] && command -v python3 >/dev/null 2>&1; then
+    # Pass path via env var (no shell interpolation = no injection risk).
+    SUMS=$(TRANSCRIPT_PATH="$TRANSCRIPT_PATH" python3 -c "
+import os, json
+path = os.environ.get('TRANSCRIPT_PATH', '')
+i = o = cc = cr = 0
+try:
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                e = json.loads(line)
+            except Exception:
+                continue
+            msg = e.get('message')
+            if isinstance(msg, dict):
+                u = msg.get('usage')
+                if isinstance(u, dict):
+                    i  += int(u.get('input_tokens', 0) or 0)
+                    o  += int(u.get('output_tokens', 0) or 0)
+                    cc += int(u.get('cache_creation_input_tokens', 0) or 0)
+                    cr += int(u.get('cache_read_input_tokens', 0) or 0)
+except Exception:
+    pass
+print(f'{i} {o} {cc} {cr}')
+" 2>/dev/null)
+    if [ -n "$SUMS" ]; then
+      IN_T=$(printf '%s' "$SUMS" | awk '{print $1}')
+      OUT_T=$(printf '%s' "$SUMS" | awk '{print $2}')
+      CACHE_C=$(printf '%s' "$SUMS" | awk '{print $3}')
+      CACHE_R=$(printf '%s' "$SUMS" | awk '{print $4}')
+    fi
+  fi
+  # Defensive: ensure all values are numeric (default to 0 if not)
+  case "$IN_T" in    ''|*[!0-9]*) IN_T=0 ;; esac
+  case "$OUT_T" in   ''|*[!0-9]*) OUT_T=0 ;; esac
+  case "$CACHE_C" in ''|*[!0-9]*) CACHE_C=0 ;; esac
+  case "$CACHE_R" in ''|*[!0-9]*) CACHE_R=0 ;; esac
+
+  # ── JSON-escape session_id (may contain unusual chars) ────────
+  ESCAPED_SESSION=$(printf '%s' "$SESSION_ID" \
+    | sed 's/\\/\\\\/g; s/"/\\"/g' 2>/dev/null \
+    | tr -d '\n\r\t' 2>/dev/null)
+  [ -z "$ESCAPED_SESSION" ] && ESCAPED_SESSION="unknown"
+
+  # ── Compose JSONL entry ────────────────────────────────────────
+  ENTRY=$(printf '{"ts":"%s","session":"%s","input_tokens":%s,"output_tokens":%s,"cache_creation_input_tokens":%s,"cache_read_input_tokens":%s}' \
+    "$NOW" "$ESCAPED_SESSION" "$IN_T" "$OUT_T" "$CACHE_C" "$CACHE_R" 2>/dev/null)
+
+  if [ -n "$ENTRY" ]; then
+    printf '%s\n' "$ENTRY" >> "$COST_FILE" 2>/dev/null || true
+  fi
+
+} 2>/dev/null
+
+# Always exit 0 — the most important line.
+exit 0

--- a/templates/hooks/stop-cost-summary.sh
+++ b/templates/hooks/stop-cost-summary.sh
@@ -23,6 +23,19 @@
 # completion. If transcript_path is missing, malformed, or empty:
 # log zeros and continue. v7 regression guard (tests/invariant-exit-zero.sh)
 # verifies this on every commit.
+#
+# ─────────────────────────────────────────────────────────────────────
+# DESIGN NOTE: ALL JSON HANDLING DONE IN A SINGLE python3 INVOCATION
+# ─────────────────────────────────────────────────────────────────────
+# Payload parsing, transcript reading, token summation, AND output JSON
+# encoding all happen inside one python3 -c block. Rationale:
+#   1. json.dumps guarantees valid JSONL even if session_id contains
+#      control characters or unusual strings (Gemini review feedback).
+#   2. Per-field safe_int catches non-numeric token values without
+#      aborting the file loop (CodeRabbit review feedback).
+#   3. Single structured call removes fragile multi-line stdout parsing
+#      with sed (Copilot review feedback on newline-in-session_id).
+#   4. Fewer shell/python boundary crossings = fewer places to break.
 
 trap 'exit 0' ERR EXIT
 
@@ -31,15 +44,13 @@ trap 'exit 0' ERR EXIT
   AUDIT_DIR="${CLAUDE_AUDIT_DIR:-.claude/audit}"
   mkdir -p "$AUDIT_DIR" 2>/dev/null || true
 
-  # .gitignore protection (defense-in-depth, same pattern as check-audit.sh)
-  # Cost logs may contain session ids which are not secrets but are also
-  # not needed in version control.
+  # .gitignore protection (defense-in-depth, same pattern as check-audit.sh).
   GITIGNORE_FILE="$AUDIT_DIR/.gitignore"
   if [ ! -f "$GITIGNORE_FILE" ] 2>/dev/null; then
     printf '*\n!.gitignore\n' > "$GITIGNORE_FILE" 2>/dev/null || true
   fi
 
-  # Date helpers with fallbacks
+  # Date helpers with fallbacks.
   TODAY=$(date +%Y-%m-%d 2>/dev/null)
   [ -z "$TODAY" ] && TODAY="unknown-date"
 
@@ -55,88 +66,89 @@ trap 'exit 0' ERR EXIT
   fi
   [ -z "$PAYLOAD" ] && PAYLOAD='{}'
 
-  # ── Extract session_id and transcript_path via python3 ─────────
-  # Use python3 for JSON-aware parsing (handles escaped chars).
-  # Pass payload via stdin pipe; never via shell-interpolated string.
-  SESSION_ID="unknown"
-  TRANSCRIPT_PATH=""
-  if command -v python3 >/dev/null 2>&1; then
-    EXTRACTED=$(printf '%s' "$PAYLOAD" | python3 -c "
+  # ── Generate JSONL entry via a single python3 call ─────────────
+  # Inputs:
+  #   stdin:   PAYLOAD (Stop hook JSON)
+  #   argv[1]: NOW (ISO 8601 UTC timestamp, shell-controlled, safe)
+  # Output:
+  #   One JSONL line on stdout (valid JSON, ready to append).
+  # Defensive:
+  #   - json.dumps handles any character safely (including control chars).
+  #   - safe_int wraps per-field int() so a bad token value (string/float)
+  #     is treated as 0 and does NOT abort the transcript scan.
+  #   - All exceptions are caught; on total failure, a minimal entry with
+  #     session=unknown and all tokens=0 is still emitted.
+  ENTRY=$(printf '%s' "$PAYLOAD" | python3 -c '
 import sys, json
+
+NOW = sys.argv[1] if len(sys.argv) > 1 else "unknown-time"
+
+def safe_int(v):
+    """Coerce anything to int; return 0 on failure. Non-aborting."""
+    try:
+        return int(v)
+    except Exception:
+        return 0
+
+# Parse Stop hook payload
 try:
-    d = json.loads(sys.stdin.read())
-    sid = d.get('session_id', 'unknown') or 'unknown'
-    tp = d.get('transcript_path', '') or ''
-    if not isinstance(sid, str): sid = str(sid)
-    if not isinstance(tp, str): tp = str(tp)
-    print(sid)
-    print(tp)
+    payload = json.loads(sys.stdin.read())
+    if not isinstance(payload, dict):
+        payload = {}
 except Exception:
-    print('unknown')
-    print('')
-" 2>/dev/null)
-    SESSION_ID=$(printf '%s' "$EXTRACTED" | sed -n '1p')
-    TRANSCRIPT_PATH=$(printf '%s' "$EXTRACTED" | sed -n '2p')
-  fi
-  [ -z "$SESSION_ID" ] && SESSION_ID="unknown"
+    payload = {}
 
-  # ── Sum tokens from transcript JSONL if available ──────────────
-  IN_T=0
-  OUT_T=0
-  CACHE_C=0
-  CACHE_R=0
+sid = payload.get("session_id") or "unknown"
+if not isinstance(sid, str):
+    sid = str(sid)
 
-  if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ] && command -v python3 >/dev/null 2>&1; then
-    # Pass path via env var (no shell interpolation = no injection risk).
-    SUMS=$(TRANSCRIPT_PATH="$TRANSCRIPT_PATH" python3 -c "
-import os, json
-path = os.environ.get('TRANSCRIPT_PATH', '')
+tp = payload.get("transcript_path") or ""
+if not isinstance(tp, str):
+    tp = ""
+
+# Sum token categories from transcript JSONL (if available)
 i = o = cc = cr = 0
-try:
-    with open(path) as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                e = json.loads(line)
-            except Exception:
-                continue
-            msg = e.get('message')
-            if isinstance(msg, dict):
-                u = msg.get('usage')
-                if isinstance(u, dict):
-                    i  += int(u.get('input_tokens', 0) or 0)
-                    o  += int(u.get('output_tokens', 0) or 0)
-                    cc += int(u.get('cache_creation_input_tokens', 0) or 0)
-                    cr += int(u.get('cache_read_input_tokens', 0) or 0)
-except Exception:
-    pass
-print(f'{i} {o} {cc} {cr}')
-" 2>/dev/null)
-    if [ -n "$SUMS" ]; then
-      IN_T=$(printf '%s' "$SUMS" | awk '{print $1}')
-      OUT_T=$(printf '%s' "$SUMS" | awk '{print $2}')
-      CACHE_C=$(printf '%s' "$SUMS" | awk '{print $3}')
-      CACHE_R=$(printf '%s' "$SUMS" | awk '{print $4}')
-    fi
-  fi
-  # Defensive: ensure all values are numeric (default to 0 if not)
-  case "$IN_T" in    ''|*[!0-9]*) IN_T=0 ;; esac
-  case "$OUT_T" in   ''|*[!0-9]*) OUT_T=0 ;; esac
-  case "$CACHE_C" in ''|*[!0-9]*) CACHE_C=0 ;; esac
-  case "$CACHE_R" in ''|*[!0-9]*) CACHE_R=0 ;; esac
+if tp:
+    try:
+        with open(tp) as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    e = json.loads(line)
+                except Exception:
+                    continue
+                if not isinstance(e, dict):
+                    continue
+                msg = e.get("message")
+                if not isinstance(msg, dict):
+                    continue
+                u = msg.get("usage")
+                if not isinstance(u, dict):
+                    continue
+                # Per-field safe_int prevents one bad value from aborting
+                # the outer loop (CodeRabbit review feedback).
+                i  += safe_int(u.get("input_tokens", 0))
+                o  += safe_int(u.get("output_tokens", 0))
+                cc += safe_int(u.get("cache_creation_input_tokens", 0))
+                cr += safe_int(u.get("cache_read_input_tokens", 0))
+    except Exception:
+        pass
 
-  # ── JSON-escape session_id (may contain unusual chars) ────────
-  ESCAPED_SESSION=$(printf '%s' "$SESSION_ID" \
-    | sed 's/\\/\\\\/g; s/"/\\"/g' 2>/dev/null \
-    | tr -d '\n\r\t' 2>/dev/null)
-  [ -z "$ESCAPED_SESSION" ] && ESCAPED_SESSION="unknown"
+entry = {
+    "ts": NOW,
+    "session": sid,
+    "input_tokens": i,
+    "output_tokens": o,
+    "cache_creation_input_tokens": cc,
+    "cache_read_input_tokens": cr,
+}
+# json.dumps with ensure_ascii=True guarantees a single ASCII-safe line.
+sys.stdout.write(json.dumps(entry, ensure_ascii=True))
+' "$NOW" 2>/dev/null)
 
-  # ── Compose JSONL entry ────────────────────────────────────────
-  ENTRY=$(printf '{"ts":"%s","session":"%s","input_tokens":%s,"output_tokens":%s,"cache_creation_input_tokens":%s,"cache_read_input_tokens":%s}' \
-    "$NOW" "$ESCAPED_SESSION" "$IN_T" "$OUT_T" "$CACHE_C" "$CACHE_R" 2>/dev/null)
-
+  # Append to cost log (silently tolerate write failures).
   if [ -n "$ENTRY" ]; then
     printf '%s\n' "$ENTRY" >> "$COST_FILE" 2>/dev/null || true
   fi

--- a/templates/settings.json
+++ b/templates/settings.json
@@ -14,6 +14,11 @@
             "type": "command",
             "command": "bash .claude/hooks/check-quality.sh",
             "timeout": 30000
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/stop-cost-summary.sh",
+            "timeout": 5000
           }
         ]
       }

--- a/tests/hooks/stop-cost-summary.test.sh
+++ b/tests/hooks/stop-cost-summary.test.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Tests for templates/hooks/stop-cost-summary.sh (v8 item 7.2)
+#
+# Verifies:
+#   1. Exits 0 on every input variant (v7 regression guard alignment)
+#   2. Correctly sums input/output/cache tokens from a fixture transcript
+#   3. Handles empty stdin, missing transcript_path, non-existent file,
+#      and malformed JSONL — all exit 0 with zeros logged
+#   4. Auto-creates .claude/audit/.gitignore (secret protection pattern)
+#   5. JSONL output is valid JSON
+
+set +e  # assertions track failures manually
+
+HOOK="$(cd "$(dirname "$0")/../.." && pwd)/templates/hooks/stop-cost-summary.sh"
+if [ ! -x "$HOOK" ]; then
+  echo "  FAIL: hook not executable at $HOOK"
+  exit 1
+fi
+
+# mktemp portability (GNU + BSD/macOS)
+TMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t idea-factory 2>/dev/null)
+if [ -z "$TMPDIR" ] || [ ! -d "$TMPDIR" ]; then
+  echo "  FAIL: could not create temp directory"
+  exit 1
+fi
+trap 'rm -rf "$TMPDIR"' EXIT
+cd "$TMPDIR" || exit 1
+
+# Capture date once to avoid midnight race
+TODAY=$(date +%Y-%m-%d)
+
+FAILED=0
+
+fail() {
+  echo "  FAIL: $1"
+  FAILED=$((FAILED + 1))
+}
+
+assert_eq() {
+  [ "$1" = "$2" ] || fail "$3 — expected '$2', got '$1'"
+}
+
+# Get the last entry's named field via python3 (defensive)
+last_field() {
+  local field="$1"
+  local f=".claude/audit/cost-$TODAY.jsonl"
+  [ -f "$f" ] || { echo ""; return; }
+  tail -1 "$f" | python3 -c "
+import json, sys
+try:
+    d = json.loads(sys.stdin.read())
+    print(d.get('$field', ''))
+except Exception:
+    print('')
+" 2>/dev/null
+}
+
+# ── Test 1: valid transcript with known token sums ───────────────
+# Fixture: 2 assistant messages with usage. Totals:
+#   input=100+200=300, output=50+50=100, cache_c=20+30=50, cache_r=10+10=20
+cat > "$TMPDIR/transcript.jsonl" <<'EOF'
+{"type":"assistant","message":{"usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":20,"cache_read_input_tokens":10}}}
+{"type":"user","message":{"content":[{"type":"text","text":"hi"}]}}
+{"type":"assistant","message":{"usage":{"input_tokens":200,"output_tokens":50,"cache_creation_input_tokens":30,"cache_read_input_tokens":10}}}
+EOF
+
+PAYLOAD="{\"session_id\":\"test-session-123\",\"transcript_path\":\"$TMPDIR/transcript.jsonl\"}"
+printf '%s' "$PAYLOAD" | bash "$HOOK"
+RC=$?
+assert_eq "$RC" "0" "T1: exit 0 with valid transcript"
+assert_eq "$(last_field input_tokens)"                "300" "T1: input_tokens summed correctly"
+assert_eq "$(last_field output_tokens)"               "100" "T1: output_tokens summed correctly"
+assert_eq "$(last_field cache_creation_input_tokens)" "50"  "T1: cache_creation summed correctly"
+assert_eq "$(last_field cache_read_input_tokens)"     "20"  "T1: cache_read summed correctly"
+assert_eq "$(last_field session)"                     "test-session-123" "T1: session_id captured"
+
+# ── Test 2: empty stdin ──────────────────────────────────────────
+echo '' | bash "$HOOK"
+RC=$?
+assert_eq "$RC" "0" "T2: exit 0 with empty stdin"
+
+# ── Test 3: missing transcript_path ──────────────────────────────
+printf '%s' '{"session_id":"abc"}' | bash "$HOOK"
+RC=$?
+assert_eq "$RC" "0" "T3: exit 0 with missing transcript_path"
+# Should log zeros for token counts
+assert_eq "$(last_field input_tokens)"  "0" "T3: input_tokens=0 when no transcript"
+assert_eq "$(last_field output_tokens)" "0" "T3: output_tokens=0 when no transcript"
+
+# ── Test 4: non-existent transcript file ─────────────────────────
+PAYLOAD='{"session_id":"x","transcript_path":"/nonexistent/path/transcript.jsonl"}'
+printf '%s' "$PAYLOAD" | bash "$HOOK"
+RC=$?
+assert_eq "$RC" "0" "T4: exit 0 with non-existent transcript file"
+assert_eq "$(last_field input_tokens)" "0" "T4: input_tokens=0 when file missing"
+
+# ── Test 5: malformed JSON payload ───────────────────────────────
+echo 'not json at all' | bash "$HOOK"
+RC=$?
+assert_eq "$RC" "0" "T5: exit 0 with malformed JSON payload"
+
+# ── Test 6: malformed transcript JSONL (some lines invalid) ──────
+# Hook should skip bad lines and sum what it can.
+cat > "$TMPDIR/bad-transcript.jsonl" <<'EOF'
+{"type":"assistant","message":{"usage":{"input_tokens":50,"output_tokens":25,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+this is not valid JSON
+{"missing":"usage"}
+{"type":"assistant","message":{"usage":{"input_tokens":50,"output_tokens":25,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+EOF
+PAYLOAD="{\"session_id\":\"y\",\"transcript_path\":\"$TMPDIR/bad-transcript.jsonl\"}"
+printf '%s' "$PAYLOAD" | bash "$HOOK"
+RC=$?
+assert_eq "$RC" "0" "T6: exit 0 with partially malformed transcript"
+assert_eq "$(last_field input_tokens)"  "100" "T6: input sums valid lines (50+50)"
+assert_eq "$(last_field output_tokens)" "50"  "T6: output sums valid lines (25+25)"
+
+# ── Test 7: empty transcript file ────────────────────────────────
+> "$TMPDIR/empty-transcript.jsonl"
+PAYLOAD="{\"session_id\":\"z\",\"transcript_path\":\"$TMPDIR/empty-transcript.jsonl\"}"
+printf '%s' "$PAYLOAD" | bash "$HOOK"
+RC=$?
+assert_eq "$RC" "0" "T7: exit 0 with empty transcript file"
+assert_eq "$(last_field input_tokens)" "0" "T7: zero tokens with empty transcript"
+
+# ── Test 8: .gitignore auto-created ──────────────────────────────
+if [ ! -f .claude/audit/.gitignore ]; then
+  fail "T8: .gitignore not auto-created in .claude/audit/"
+fi
+
+# ── Test 9: all JSONL entries are valid JSON ─────────────────────
+python3 -c "
+import json
+f = '.claude/audit/cost-$TODAY.jsonl'
+try:
+    with open(f) as fh:
+        for line in fh:
+            if line.strip():
+                json.loads(line)
+    exit(0)
+except Exception as e:
+    print(f'FAIL: invalid JSONL — {e}')
+    exit(1)
+" || fail "T9: not all JSONL entries valid JSON"
+
+# ── Test 10: shell injection attempt in transcript_path ──────────
+# Verifies that no shell metacharacter in transcript_path causes
+# command execution (regression test for code-injection class).
+# Hook should treat path literally; bogus path → not a file → zero tokens.
+PAYLOAD='{"session_id":"inj","transcript_path":"/tmp/$(touch /tmp/idea-factory-injection-canary).jsonl"}'
+printf '%s' "$PAYLOAD" | bash "$HOOK"
+RC=$?
+assert_eq "$RC" "0" "T10: exit 0 with injection-pattern path"
+if [ -f /tmp/idea-factory-injection-canary ]; then
+  fail "T10: SHELL INJECTION — canary file was created!"
+  rm -f /tmp/idea-factory-injection-canary
+fi
+
+# ── Summary ───────────────────────────────────────────────────────
+if [ "$FAILED" -gt 0 ]; then
+  echo ""
+  echo "stop-cost-summary: $FAILED assertion(s) failed"
+  exit 1
+fi
+
+echo "stop-cost-summary: 14 assertions passed"
+exit 0

--- a/tests/hooks/stop-cost-summary.test.sh
+++ b/tests/hooks/stop-cost-summary.test.sh
@@ -30,6 +30,7 @@ cd "$TMPDIR" || exit 1
 TODAY=$(date +%Y-%m-%d)
 
 FAILED=0
+ASSERTIONS=0
 
 fail() {
   echo "  FAIL: $1"
@@ -37,6 +38,7 @@ fail() {
 }
 
 assert_eq() {
+  ASSERTIONS=$((ASSERTIONS + 1))
   [ "$1" = "$2" ] || fail "$3 — expected '$2', got '$1'"
 }
 
@@ -122,6 +124,23 @@ RC=$?
 assert_eq "$RC" "0" "T7: exit 0 with empty transcript file"
 assert_eq "$(last_field input_tokens)" "0" "T7: zero tokens with empty transcript"
 
+# ── Test 7b: non-numeric token values in transcript ──────────────
+# CodeRabbit review feedback: ensure one bad usage value doesn't abort
+# the whole file scan. Per-field safe_int should treat "abc" as 0 and
+# continue summing subsequent valid lines.
+cat > "$TMPDIR/non-numeric-transcript.jsonl" <<'EOF'
+{"type":"assistant","message":{"usage":{"input_tokens":"abc","output_tokens":10,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+{"type":"assistant","message":{"usage":{"input_tokens":50,"output_tokens":25,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+EOF
+PAYLOAD="{\"session_id\":\"nn\",\"transcript_path\":\"$TMPDIR/non-numeric-transcript.jsonl\"}"
+printf '%s' "$PAYLOAD" | bash "$HOOK"
+RC=$?
+assert_eq "$RC" "0" "T7b: exit 0 with non-numeric token values"
+# "abc" treated as 0 + 50 from valid line = 50
+assert_eq "$(last_field input_tokens)"  "50" "T7b: non-numeric 'abc' → 0, numeric 50 counted"
+# 10 from first line (output=10 was numeric) + 25 from second line = 35
+assert_eq "$(last_field output_tokens)" "35" "T7b: output=10+25=35 (both numeric, not skipped)"
+
 # ── Test 8: .gitignore auto-created ──────────────────────────────
 if [ ! -f .claude/audit/.gitignore ]; then
   fail "T8: .gitignore not auto-created in .claude/audit/"
@@ -146,21 +165,25 @@ except Exception as e:
 # Verifies that no shell metacharacter in transcript_path causes
 # command execution (regression test for code-injection class).
 # Hook should treat path literally; bogus path → not a file → zero tokens.
-PAYLOAD='{"session_id":"inj","transcript_path":"/tmp/$(touch /tmp/idea-factory-injection-canary).jsonl"}'
+#
+# Canary uses TMPDIR path (not fixed /tmp path) so stale canary from
+# prior runs or parallel processes cannot cause flakes (Copilot review).
+CANARY="$TMPDIR/injection-canary"
+rm -f "$CANARY"
+PAYLOAD="{\"session_id\":\"inj\",\"transcript_path\":\"$TMPDIR/\$(touch $CANARY).jsonl\"}"
 printf '%s' "$PAYLOAD" | bash "$HOOK"
 RC=$?
 assert_eq "$RC" "0" "T10: exit 0 with injection-pattern path"
-if [ -f /tmp/idea-factory-injection-canary ]; then
+if [ -f "$CANARY" ]; then
   fail "T10: SHELL INJECTION — canary file was created!"
-  rm -f /tmp/idea-factory-injection-canary
 fi
 
 # ── Summary ───────────────────────────────────────────────────────
 if [ "$FAILED" -gt 0 ]; then
   echo ""
-  echo "stop-cost-summary: $FAILED assertion(s) failed"
+  echo "stop-cost-summary: $((ASSERTIONS - FAILED))/$ASSERTIONS passed, $FAILED failed"
   exit 1
 fi
 
-echo "stop-cost-summary: 14 assertions passed"
+echo "stop-cost-summary: $ASSERTIONS assertions passed"
 exit 0


### PR DESCRIPTION
## 변경 사항

f6a7838 feat: v8 item 7.2 — 세션 종료 시 토큰/비용 자동 집계 Stop hook (#9)

```
 4 files changed, 327 insertions(+), 5 deletions(-)
```

Closes #9

---
🤖 Generated by Claude Code [claude-opus-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic cost tracking on session stop that logs per-session token usage by category into a local audit file.

* **Tests**
  * Comprehensive end-to-end test suite covering normal, empty, malformed, and edge-case transcripts plus security validation against command injection.

* **Documentation**
  * Backlog item moved to in-progress with implementation details and merge guidance updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->