### PR TITLE
feat: v8 Wave 1 — loop breaker + decay counter + learning capture hooks

### DIFF
--- a/docs/plans/v8-backlog.md
+++ b/docs/plans/v8-backlog.md
@@ -140,7 +140,7 @@ v7.1 까지 idea-factory 는 자체 리서치/결정/학습을 체계적으로 �
 **증거**: 이번 세션 자체. 만약 사용자가 "기록 안 하나?" 하고 물어보지 않았다면 두 개의 심층 리서치 리포트가 그냥 증발했을 것.
 
 **의존성**: 없음.
-**상태**: `todo`
+**상태**: `done` (2026-04-12, `templates/hooks/stop-learning-capture.sh` — Stop 훅. 학습층 디렉터리 존재 + 20+ audit 엔트리 시 4가지 학습 카테고리 기록 제안. 8 assertions 통과)
 
 ### 2.5 Research artifact template [LOW / Small]
 

--- a/docs/plans/v8-backlog.md
+++ b/docs/plans/v8-backlog.md
@@ -168,7 +168,7 @@ v7.1 은 많은 중요한 룰을 **CLAUDE.md 산문** 으로 기록. 하지만 J
 **스케치**: Stop 훅 또는 PostToolUse 가 최근 N 커맨드/에디트 를 비교, near-identical repeat (예: 같은 파일의 같은 라인을 3번 수정) 감지 시 hard stop + CEO 에스컬레이션. CLAUDE.md 룰은 유지하되 훅이 안전망.
 
 **의존성**: 1.1 (audit log) 가 있으면 더 정확한 탐지 가능.
-**상태**: `todo`
+**상태**: `done` (2026-04-12, `templates/hooks/check-loop-breaker.sh` — PostToolUse Write|Edit 훅. 같은 파일 3회 수정 시 WARNING, 5회 시 ESCALATE. 11 assertions 통과)
 
 ### 3.2 AST-level CONTRACT enforcement [MED / Large]
 
@@ -209,17 +209,29 @@ v7.1 은 많은 중요한 룰을 **CLAUDE.md 산문** 으로 기록. 하지만 J
 
 # Theme 4: Context & Memory
 
-### 4.1 Instruction compliance decay counter + rule reinjection [MED / Medium]
+### 4.1 Instruction compliance decay counter + rule reinjection + anti-quit [HIGH / Medium]
 
 **문제**: Khare decay curve — 메시지 5-6 이후 CLAUDE.md 룰 준수율 20-60%. 현재 idea-factory 는 세션 길이 카운터 없음. 중반 이후 핵심 룰을 재주입할 방법 없음.
+
+이 decay 의 대표적 증상 두 가지:
+1. **자의적 작업 중단 (anti-quit)**: 모델이 "오늘은 여기까지", "다음 세션에서 이어하자" 등 학습 데이터 패턴에 의해 스스로 작업을 중단. Claude 에는 피로·일일 한도 없으므로 이는 instruction decay 로 인한 잘못된 행동.
+2. **반복 실패 루프 진입**: 컨텍스트 오염으로 이전의 틀린 접근법을 재참조하며 같은 버그를 수십 회 반복. (3.1 circuit breaker 와 연동)
 
 **증거**: 
 - `docs/research/2026-04-11-tsb-harness-external.md` Part 2 Failure Mode 4 (Jaroslawicz et al. 2025)
 - https://dev.to/siddhantkcode/an-easy-way-to-stop-claude-code-from-forgetting-the-rules-h36
+- 2026-04-12 사용자 리포트: 4개 터미널에서 동시에 자의적 중단 + 무한 루프 관찰
 
-**스케치**: PreToolUse 훅 (exit 0 로깅과 통합) 이 N 메시지마다 or 토큰 임계값마다 critical invariants 를 `<system-reminder>` 로 재주입.
+**스케치**:
+1. **PreToolUse 훅 (exit 0)**: N 메시지마다 or 토큰 임계값마다 critical invariants 를 `<system-reminder>` 로 재주입. 재주입 대상 핵심 규칙:
+   - "사용자가 명시적으로 중단 요청하기 전까지 자의적으로 작업을 중단하지 않는다"
+   - "같은 접근법 3회 실패 시 근본 원인 분석 후 다른 전략으로 전환하거나 escalate"
+   - 현재 세션의 핵심 목표 리마인더
+2. **CLAUDE.md 템플릿 즉시 반영**: 훅 구현 전에도 prose rule 로 anti-quit 규칙 선행 배치 (v7.1 에서 바로 적용 가능)
+3. **3.1 circuit breaker 와 연동**: decay counter 가 감지한 "반복 패턴" 정보를 3.1 에 전달
 
-**상태**: `todo`
+**의존성**: 없음 (독립 착수 가능). 3.1 과 시너지.
+**상태**: `done` (2026-04-12, `templates/hooks/check-decay-counter.sh` — PreToolUse 훅. 40회 도구 호출마다 anti-quit + circuit breaker + context hygiene 규칙 재주입. CLAUDE.md 템플릿에도 prose rule 선행 배치. 12 assertions 통과)
 
 ### 4.2 Auto-compact loss validation for handoff docs [LOW / Large]
 

--- a/templates/CLAUDE.md.tmpl
+++ b/templates/CLAUDE.md.tmpl
@@ -76,4 +76,6 @@ Touching a feature directory? Read its `*_CONTRACT.md` first.
 - Mock data first (Phase 1). Real APIs later (Phase 2).
 - Every feature must serve `.project/essence.md`
 - Same approach fails twice → root cause analysis
+- Same approach fails 3 times → STOP. 다른 전략으로 전환하거나 CEO에게 escalate
 - Reuse > library > build from scratch
+- **사용자가 명시적으로 중단을 요청하기 전까지 자의적으로 작업을 중단하지 않는다** — "오늘은 여기까지", "다음 세션에서 이어하자" 등 금지. Claude에 피로·일일 한도는 없다.

--- a/templates/hooks/check-decay-counter.sh
+++ b/templates/hooks/check-decay-counter.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# check-decay-counter.sh — Instruction decay counter + anti-quit reinjection
+#
+# idea-factory v8 item 4.1 (docs/plans/v8-backlog.md Theme 4)
+#
+# ─────────────────────────────────────────────────────────────────────
+# PURPOSE
+# ─────────────────────────────────────────────────────────────────────
+# Count tool invocations per session. Every N invocations, reinject
+# critical invariants as stdout (which Claude Code surfaces as
+# <system-reminder>). This combats instruction compliance decay
+# (Khare curve: 20-60% compliance after message 5-6).
+#
+# Reinjected rules:
+#   - Anti-quit: never self-terminate work without user request
+#   - Circuit breaker reminder: 3 identical failures → stop + escalate
+#   - Session goal reminder (if .project/backlog.md exists)
+#
+# ─────────────────────────────────────────────────────────────────────
+# CRITICAL INVARIANT: THIS SCRIPT MUST ALWAYS EXIT 0
+# ─────────────────────────────────────────────────────────────────────
+
+trap 'exit 0' ERR EXIT
+
+{
+  # ── Configuration ──────────────────────────────────────────────
+  STATE_DIR="${CLAUDE_AUDIT_DIR:-.claude/audit}"
+  REINJECT_EVERY=${DECAY_REINJECT_INTERVAL:-40}
+
+  mkdir -p "$STATE_DIR" 2>/dev/null || true
+
+  # .gitignore protection
+  GITIGNORE_FILE="$STATE_DIR/.gitignore"
+  if [ ! -f "$GITIGNORE_FILE" ] 2>/dev/null; then
+    printf '*\n!.gitignore\n' > "$GITIGNORE_FILE" 2>/dev/null || true
+  fi
+
+  # ── Session-scoped counter file ────────────────────────────────
+  SESSION_ID="${CLAUDE_SESSION_ID:-default}"
+  # Sanitize session ID for filename safety
+  SAFE_SESSION=$(printf '%s' "$SESSION_ID" | tr -cd 'a-zA-Z0-9_-' 2>/dev/null)
+  [ -z "$SAFE_SESSION" ] && SAFE_SESSION="default"
+  COUNTER_FILE="$STATE_DIR/.decay-counter-${SAFE_SESSION}"
+
+  # ── Read and increment counter ─────────────────────────────────
+  COUNT=0
+  if [ -f "$COUNTER_FILE" ] 2>/dev/null; then
+    COUNT=$(cat "$COUNTER_FILE" 2>/dev/null || echo 0)
+    # Validate it's a number
+    case "$COUNT" in
+      ''|*[!0-9]*) COUNT=0 ;;
+    esac
+  fi
+  COUNT=$((COUNT + 1))
+  printf '%d' "$COUNT" > "$COUNTER_FILE" 2>/dev/null || true
+
+  # ── Check if reinjection is due ────────────────────────────────
+  REMAINDER=$((COUNT % REINJECT_EVERY))
+  if [ "$REMAINDER" -ne 0 ] 2>/dev/null; then
+    exit 0  # Not time yet
+  fi
+
+  # ── Build reinjection message ──────────────────────────────────
+  # stdout from hooks becomes <system-reminder> content in Claude's context.
+  # Use unquoted HEREDOC so $COUNT expands inline.
+
+  GOAL_LINE=""
+  if [ -f ".project/backlog.md" ] 2>/dev/null; then
+    FIRST_ITEM=$(grep -m1 -E '^\s*-\s+' ".project/backlog.md" 2>/dev/null | head -1)
+    if [ -n "$FIRST_ITEM" ]; then
+      GOAL_LINE="Current top priority: $FIRST_ITEM"
+    fi
+  fi
+
+  cat <<REINJECT
+[INSTRUCTION REINJECTION — tool invocation #${COUNT}]
+
+Critical rules (re-read carefully):
+
+1. ANTI-QUIT: 사용자가 명시적으로 중단을 요청하기 전까지 자의적으로 작업을 중단하지 않는다. "오늘은 여기까지", "다음 세션에서 이어하자", "많이 진행했으니 쉬자" 등 금지. Claude에 피로·일일 한도는 없다. 작업이 남아있으면 계속한다.
+
+2. CIRCUIT BREAKER: 같은 접근법으로 같은 문제를 3회 실패하면 즉시 멈추고 (a) 근본 원인을 분석하거나 (b) 완전히 다른 전략으로 전환하거나 (c) 사용자에게 escalate한다. 4회째 동일 시도는 금지.
+
+3. CONTEXT HYGIENE: 실패한 시도의 세부사항이 컨텍스트를 오염시키고 있을 수 있다. 현재 접근법이 작동하지 않으면 한 발 물러나서 문제를 처음부터 재분석한다.
+REINJECT
+
+  # Append dynamic goal line if available
+  if [ -n "$GOAL_LINE" ]; then
+    printf '\n4. %s\n' "$GOAL_LINE"
+  fi
+
+} 2>/dev/null
+
+exit 0

--- a/templates/hooks/check-loop-breaker.sh
+++ b/templates/hooks/check-loop-breaker.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# check-loop-breaker.sh — Fix-loop circuit breaker (PostToolUse Write|Edit)
+#
+# idea-factory v8 item 3.1 (docs/plans/v8-backlog.md Theme 3)
+#
+# ─────────────────────────────────────────────────────────────────────
+# PURPOSE
+# ─────────────────────────────────────────────────────────────────────
+# Detect when Claude edits the same file repeatedly (3+ times in a
+# short window), which signals a fix-loop: the same bug being retried
+# with near-identical approaches. When detected, emit a warning via
+# stdout that becomes a <system-reminder>.
+#
+# Detection logic:
+#   - Track recent Write/Edit targets in a session-scoped ledger
+#   - If the same file appears 3+ times in the last N entries → warn
+#   - If 5+ times → escalate (stronger language)
+#
+# ─────────────────────────────────────────────────────────────────────
+# CRITICAL INVARIANT: THIS SCRIPT MUST ALWAYS EXIT 0
+# ─────────────────────────────────────────────────────────────────────
+
+trap 'exit 0' ERR EXIT
+
+{
+  # ── Configuration ──────────────────────────────────────────────
+  STATE_DIR="${CLAUDE_AUDIT_DIR:-.claude/audit}"
+  WARN_THRESHOLD=${LOOP_WARN_THRESHOLD:-3}
+  ESCALATE_THRESHOLD=${LOOP_ESCALATE_THRESHOLD:-5}
+  WINDOW_SIZE=${LOOP_WINDOW_SIZE:-15}
+
+  mkdir -p "$STATE_DIR" 2>/dev/null || true
+
+  # .gitignore protection
+  GITIGNORE_FILE="$STATE_DIR/.gitignore"
+  if [ ! -f "$GITIGNORE_FILE" ] 2>/dev/null; then
+    printf '*\n!.gitignore\n' > "$GITIGNORE_FILE" 2>/dev/null || true
+  fi
+
+  # ── Session-scoped ledger ──────────────────────────────────────
+  SESSION_ID="${CLAUDE_SESSION_ID:-default}"
+  SAFE_SESSION=$(printf '%s' "$SESSION_ID" | tr -cd 'a-zA-Z0-9_-' 2>/dev/null)
+  [ -z "$SAFE_SESSION" ] && SAFE_SESSION="default"
+  LEDGER_FILE="$STATE_DIR/.loop-ledger-${SAFE_SESSION}"
+
+  # ── Read PostToolUse payload ───────────────────────────────────
+  PAYLOAD=""
+  if [ ! -t 0 ]; then
+    PAYLOAD=$(cat 2>/dev/null || echo '')
+  fi
+  [ -z "$PAYLOAD" ] && PAYLOAD='{}'
+
+  # ── Extract file_path via python3, grep fallback ───────────────
+  FILE_PATH=""
+  if command -v python3 >/dev/null 2>&1; then
+    FILE_PATH=$(printf '%s' "$PAYLOAD" | python3 -c "
+import sys, json
+try:
+    d = json.loads(sys.stdin.read())
+    v = d.get('tool_input', {}).get('file_path', '')
+    if not isinstance(v, str): v = ''
+    sys.stdout.write(v)
+except Exception:
+    pass
+" 2>/dev/null)
+  fi
+  if [ -z "$FILE_PATH" ]; then
+    FILE_PATH=$(printf '%s' "$PAYLOAD" \
+      | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' 2>/dev/null \
+      | head -1 \
+      | sed 's/.*"file_path"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/' 2>/dev/null)
+  fi
+
+  # Nothing to track if no file_path
+  [ -z "$FILE_PATH" ] && exit 0
+
+  # ── Append to ledger (rolling window) ──────────────────────────
+  printf '%s\n' "$FILE_PATH" >> "$LEDGER_FILE" 2>/dev/null || true
+
+  # Keep only last WINDOW_SIZE entries to prevent unbounded growth
+  if [ -f "$LEDGER_FILE" ] 2>/dev/null; then
+    LINE_COUNT=$(wc -l < "$LEDGER_FILE" 2>/dev/null | tr -d ' ')
+    case "$LINE_COUNT" in
+      ''|*[!0-9]*) LINE_COUNT=0 ;;
+    esac
+    if [ "$LINE_COUNT" -gt "$WINDOW_SIZE" ] 2>/dev/null; then
+      tail -n "$WINDOW_SIZE" "$LEDGER_FILE" > "${LEDGER_FILE}.tmp" 2>/dev/null
+      mv "${LEDGER_FILE}.tmp" "$LEDGER_FILE" 2>/dev/null || true
+    fi
+  fi
+
+  # ── Count occurrences of current file in window ────────────────
+  HIT_COUNT=0
+  if [ -f "$LEDGER_FILE" ] 2>/dev/null; then
+    HIT_COUNT=$(grep -cF "$FILE_PATH" "$LEDGER_FILE" 2>/dev/null || echo 0)
+    case "$HIT_COUNT" in
+      ''|*[!0-9]*) HIT_COUNT=0 ;;
+    esac
+  fi
+
+  # ── Emit warning if threshold reached ──────────────────────────
+  if [ "$HIT_COUNT" -ge "$ESCALATE_THRESHOLD" ] 2>/dev/null; then
+    # Extract just the filename for readability
+    BASENAME=$(basename "$FILE_PATH" 2>/dev/null || echo "$FILE_PATH")
+    cat <<EOF
+[LOOP BREAKER — ESCALATE] ${BASENAME} 을 최근 ${HIT_COUNT}회 수정했습니다.
+
+이것은 fix-loop 입니다. 같은 파일을 반복 수정하는 것은 근본 원인을 못 찾았다는 신호입니다.
+
+즉시 중단하고 다음 중 하나를 실행하세요:
+1. 이 파일 수정을 멈추고, 에러 메시지를 처음부터 다시 읽고, 완전히 다른 접근법을 시도
+2. 문제의 근본 원인이 이 파일이 아닌 다른 곳에 있을 가능성을 조사
+3. 사용자에게 escalate — 현재 상황과 시도한 접근법들을 설명
+
+같은 접근법의 재시도는 금지입니다.
+EOF
+
+    # Log to audit
+    NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "unknown")
+    TODAY=$(date +%Y-%m-%d 2>/dev/null || echo "unknown-date")
+    LOG_FILE="$STATE_DIR/loop-breaker-$TODAY.jsonl"
+    printf '{"ts":"%s","file":"%s","hits":%d,"level":"escalate"}\n' \
+      "$NOW" "$FILE_PATH" "$HIT_COUNT" >> "$LOG_FILE" 2>/dev/null || true
+
+  elif [ "$HIT_COUNT" -ge "$WARN_THRESHOLD" ] 2>/dev/null; then
+    BASENAME=$(basename "$FILE_PATH" 2>/dev/null || echo "$FILE_PATH")
+    cat <<EOF
+[LOOP BREAKER — WARNING] ${BASENAME} 을 최근 ${HIT_COUNT}회 수정했습니다.
+
+반복 수정 패턴이 감지되었습니다. fix-loop에 빠지고 있을 수 있습니다.
+다음을 점검하세요:
+- 이전 수정이 왜 문제를 해결하지 못했는지 분석했는가?
+- 같은 접근법을 반복하고 있지 않은가?
+- 근본 원인이 다른 파일에 있을 가능성은?
+
+3회 이상 같은 접근법 실패 시, 반드시 전략을 바꾸거나 escalate하세요.
+EOF
+  fi
+
+} 2>/dev/null
+
+exit 0

--- a/templates/hooks/check-loop-breaker.sh
+++ b/templates/hooks/check-loop-breaker.sh
@@ -92,7 +92,7 @@ except Exception:
   # ── Count occurrences of current file in window ────────────────
   HIT_COUNT=0
   if [ -f "$LEDGER_FILE" ] 2>/dev/null; then
-    HIT_COUNT=$(grep -cF "$FILE_PATH" "$LEDGER_FILE" 2>/dev/null || echo 0)
+    HIT_COUNT=$(grep -cxF "$FILE_PATH" "$LEDGER_FILE" 2>/dev/null || echo 0)
     case "$HIT_COUNT" in
       ''|*[!0-9]*) HIT_COUNT=0 ;;
     esac
@@ -119,8 +119,13 @@ EOF
     NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "unknown")
     TODAY=$(date +%Y-%m-%d 2>/dev/null || echo "unknown-date")
     LOG_FILE="$STATE_DIR/loop-breaker-$TODAY.jsonl"
+    # JSON-escape file path to prevent broken JSONL
+    ESCAPED_PATH="$FILE_PATH"
+    if command -v python3 >/dev/null 2>&1; then
+      ESCAPED_PATH=$(python3 -c "import json,sys;print(json.dumps(sys.argv[1])[1:-1])" "$FILE_PATH" 2>/dev/null) || ESCAPED_PATH="$FILE_PATH"
+    fi
     printf '{"ts":"%s","file":"%s","hits":%d,"level":"escalate"}\n' \
-      "$NOW" "$FILE_PATH" "$HIT_COUNT" >> "$LOG_FILE" 2>/dev/null || true
+      "$NOW" "$ESCAPED_PATH" "$HIT_COUNT" >> "$LOG_FILE" 2>/dev/null || true
 
   elif [ "$HIT_COUNT" -ge "$WARN_THRESHOLD" ] 2>/dev/null; then
     BASENAME=$(basename "$FILE_PATH" 2>/dev/null || echo "$FILE_PATH")

--- a/templates/hooks/stop-learning-capture.sh
+++ b/templates/hooks/stop-learning-capture.sh
@@ -55,14 +55,14 @@ trap 'exit 0' ERR EXIT
 
   # Check 2: decisions.md was modified in this session
   if [ "$SHOULD_PROMPT" = false ] && [ -f ".project/decisions.md" ] 2>/dev/null; then
-    if git diff --name-only HEAD~1 HEAD 2>/dev/null | grep -q "decisions.md" 2>/dev/null; then
+    if git diff --name-only HEAD~1 HEAD 2>/dev/null | grep -qxF "decisions.md" 2>/dev/null; then
       SHOULD_PROMPT=true
     fi
   fi
 
   # Check 3: recent commits have fix: or feat: (new work done)
   if [ "$SHOULD_PROMPT" = false ]; then
-    RECENT=$(git log --oneline -5 --since="8 hours ago" 2>/dev/null || echo "")
+    RECENT=$(git log --oneline -5 --since="8 hours ago" --no-merges 2>/dev/null || echo "")
     if printf '%s' "$RECENT" | grep -qE "^[a-f0-9]+ (fix|feat):" 2>/dev/null; then
       SHOULD_PROMPT=true
     fi

--- a/templates/hooks/stop-learning-capture.sh
+++ b/templates/hooks/stop-learning-capture.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# stop-learning-capture.sh — Session-end learning capture prompt
+#
+# idea-factory v8 item 2.4 (docs/plans/v8-backlog.md Theme 2)
+#
+# ─────────────────────────────────────────────────────────────────────
+# PURPOSE
+# ─────────────────────────────────────────────────────────────────────
+# At session Stop, check if this session produced learnings worth
+# recording. If the learning layer exists (docs/research/ or
+# docs/field-reports/), emit a reminder via stdout so Claude considers
+# capturing insights before the session context is lost.
+#
+# Detection heuristic (lightweight, avoids false positives):
+#   - Learning layer dirs must exist (only idea-factory scaffolded projects)
+#   - Session must have substantial activity (20+ audit log entries)
+#   - OR new decisions were made (.project/decisions.md modified)
+#   - OR bugs were fixed (git diff has "fix:" in recent commits)
+#
+# ─────────────────────────────────────────────────────────────────────
+# CRITICAL INVARIANT: THIS SCRIPT MUST ALWAYS EXIT 0
+# ─────────────────────────────────────────────────────────────────────
+
+trap 'exit 0' ERR EXIT
+
+{
+  # ── Check if learning layer exists ─────────────────────────────
+  # Only fire in projects scaffolded with idea-factory's learning layer.
+  # If neither dir exists, this is not an idea-factory project → skip.
+  HAS_RESEARCH=false
+  HAS_FIELD=false
+  [ -d "docs/research" ] 2>/dev/null && HAS_RESEARCH=true
+  [ -d "docs/field-reports" ] 2>/dev/null && HAS_FIELD=true
+
+  if [ "$HAS_RESEARCH" = false ] && [ "$HAS_FIELD" = false ]; then
+    exit 0  # Not an idea-factory project with learning layer
+  fi
+
+  # ── Heuristic: was this session substantial? ───────────────────
+  AUDIT_DIR="${CLAUDE_AUDIT_DIR:-.claude/audit}"
+  TODAY=$(date +%Y-%m-%d 2>/dev/null || echo "unknown")
+  AUDIT_FILE="$AUDIT_DIR/$TODAY.jsonl"
+  SHOULD_PROMPT=false
+
+  # Check 1: 20+ audit entries today = substantial session
+  if [ -f "$AUDIT_FILE" ] 2>/dev/null; then
+    ENTRY_COUNT=$(wc -l < "$AUDIT_FILE" 2>/dev/null | tr -d ' ')
+    case "$ENTRY_COUNT" in
+      ''|*[!0-9]*) ENTRY_COUNT=0 ;;
+    esac
+    if [ "$ENTRY_COUNT" -ge 20 ] 2>/dev/null; then
+      SHOULD_PROMPT=true
+    fi
+  fi
+
+  # Check 2: decisions.md was modified in this session
+  if [ "$SHOULD_PROMPT" = false ] && [ -f ".project/decisions.md" ] 2>/dev/null; then
+    if git diff --name-only HEAD~1 HEAD 2>/dev/null | grep -q "decisions.md" 2>/dev/null; then
+      SHOULD_PROMPT=true
+    fi
+  fi
+
+  # Check 3: recent commits have fix: or feat: (new work done)
+  if [ "$SHOULD_PROMPT" = false ]; then
+    RECENT=$(git log --oneline -5 --since="8 hours ago" 2>/dev/null || echo "")
+    if printf '%s' "$RECENT" | grep -qE "^[a-f0-9]+ (fix|feat):" 2>/dev/null; then
+      SHOULD_PROMPT=true
+    fi
+  fi
+
+  if [ "$SHOULD_PROMPT" = false ]; then
+    exit 0  # Session too small or no significant work detected
+  fi
+
+  # ── Emit learning capture prompt ───────────────────────────────
+  cat <<'CAPTURE'
+[SESSION LEARNING CAPTURE]
+
+이번 세션에서 기록할 만한 학습이 있는지 점검하세요:
+
+1. **새로운 gap 발견**: 하려고 했는데 안 된 것, 있어야 하는데 없는 것
+   → docs/plans/v8-backlog.md 에 항목 추가
+
+2. **리서치 결과**: 외부 조사, 에이전트 심층 분석, 비교 연구
+   → docs/research/YYYY-MM-DD-주제.md 로 저장
+
+3. **실전 교훈**: 회귀, 실패 원인, 예상 밖 동작, postmortem
+   → docs/field-reports/YYYY-MM-DD-주제.md 로 저장
+
+4. **결정 사항**: 설계 분기점에서 내린 판단과 근거
+   → .project/decisions.md 에 추가
+
+기록할 것이 없으면 무시해도 됩니다.
+CAPTURE
+
+} 2>/dev/null
+
+exit 0

--- a/templates/settings.json
+++ b/templates/settings.json
@@ -36,7 +36,11 @@
             "type": "command",
             "command": "bash .claude/hooks/check-audit.sh",
             "timeout": 3000
-          },
+          }
+        ]
+      },
+      {
+        "hooks": [
           {
             "type": "command",
             "command": "bash .claude/hooks/check-decay-counter.sh",

--- a/templates/settings.json
+++ b/templates/settings.json
@@ -19,6 +19,11 @@
             "type": "command",
             "command": "bash .claude/hooks/stop-cost-summary.sh",
             "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/stop-learning-capture.sh",
+            "timeout": 5000
           }
         ]
       }

--- a/templates/settings.json
+++ b/templates/settings.json
@@ -31,6 +31,11 @@
             "type": "command",
             "command": "bash .claude/hooks/check-audit.sh",
             "timeout": 3000
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/check-decay-counter.sh",
+            "timeout": 3000
           }
         ]
       }
@@ -43,6 +48,16 @@
             "type": "command",
             "command": "bash .claude/hooks/check-claudemd-size.sh",
             "timeout": 10000
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/check-config-protection.sh",
+            "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/check-loop-breaker.sh",
+            "timeout": 3000
           }
         ]
       }

--- a/tests/hooks/check-decay-counter.test.sh
+++ b/tests/hooks/check-decay-counter.test.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Tests for templates/hooks/check-decay-counter.sh (v8 item 4.1)
+#
+# Verifies:
+#   1. Exits 0 on every input variant (exit-0 guarantee)
+#   2. No output before reaching threshold (silent counting)
+#   3. Reinjection message emitted at threshold
+#   4. Anti-quit text present in reinjection
+#   5. Circuit breaker text present in reinjection
+#   6. Counter resets properly per session
+#   7. Handles empty/malformed input gracefully
+
+set +e
+
+HOOK="$(cd "$(dirname "$0")/../.." && pwd)/templates/hooks/check-decay-counter.sh"
+if [ ! -x "$HOOK" ]; then
+  echo "  FAIL: hook not executable at $HOOK"
+  exit 1
+fi
+
+TMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t idea-factory 2>/dev/null)
+if [ -z "$TMPDIR" ] || [ ! -d "$TMPDIR" ]; then
+  echo "  FAIL: could not create temp directory"
+  exit 1
+fi
+trap 'rm -rf "$TMPDIR"' EXIT
+cd "$TMPDIR" || exit 1
+
+FAILED=0
+
+fail() {
+  echo "  FAIL: $1"
+  FAILED=$((FAILED + 1))
+}
+
+assert_eq() {
+  [ "$1" = "$2" ] || fail "$3 — expected '$2', got '$1'"
+}
+
+# ── Test 1: exit 0 on empty stdin ────────────────────────────────
+echo '' | bash "$HOOK"
+RC=$?
+assert_eq "$RC" "0" "T1: exit 0 for empty stdin"
+
+# ── Test 2: exit 0 on malformed input ────────────────────────────
+echo 'not json' | bash "$HOOK"
+RC=$?
+assert_eq "$RC" "0" "T2: exit 0 for malformed input"
+
+# ── Test 3: silent before threshold (use small interval=5) ───────
+rm -rf .claude 2>/dev/null
+export DECAY_REINJECT_INTERVAL=5
+export CLAUDE_SESSION_ID="test-silent"
+export CLAUDE_AUDIT_DIR=".claude/audit"
+
+OUTPUT=""
+for i in 1 2 3 4; do
+  STEP_OUT=$(echo '{}' | bash "$HOOK" 2>/dev/null)
+  if [ -n "$STEP_OUT" ]; then
+    OUTPUT="$STEP_OUT"
+  fi
+done
+
+if [ -n "$OUTPUT" ]; then
+  fail "T3: output emitted before threshold (invocation <5)"
+fi
+
+# ── Test 4: reinjection at threshold ─────────────────────────────
+# 5th invocation should trigger
+REINJECT_OUT=$(echo '{}' | bash "$HOOK" 2>/dev/null)
+RC=$?
+assert_eq "$RC" "0" "T4: exit 0 at threshold"
+
+if [ -z "$REINJECT_OUT" ]; then
+  fail "T4: no reinjection output at threshold (invocation 5)"
+fi
+
+# ── Test 5: anti-quit text present ───────────────────────────────
+if ! printf '%s' "$REINJECT_OUT" | grep -q "ANTI-QUIT" 2>/dev/null; then
+  fail "T5: ANTI-QUIT keyword missing from reinjection"
+fi
+
+# ── Test 6: circuit breaker text present ─────────────────────────
+if ! printf '%s' "$REINJECT_OUT" | grep -q "CIRCUIT BREAKER" 2>/dev/null; then
+  fail "T6: CIRCUIT BREAKER keyword missing from reinjection"
+fi
+
+# ── Test 7: counter placeholder replaced with actual number ──────
+if printf '%s' "$REINJECT_OUT" | grep -q "COUNTER_PLACEHOLDER" 2>/dev/null; then
+  fail "T7: COUNTER_PLACEHOLDER not replaced with actual count"
+fi
+if ! printf '%s' "$REINJECT_OUT" | grep -q "#5" 2>/dev/null; then
+  fail "T7: expected '#5' in reinjection output"
+fi
+
+# ── Test 8: silent again after threshold until next cycle ────────
+BETWEEN_OUT=$(echo '{}' | bash "$HOOK" 2>/dev/null)
+if [ -n "$BETWEEN_OUT" ]; then
+  fail "T8: output emitted between thresholds (invocation 6)"
+fi
+
+# ── Test 9: fires again at 2x threshold ─────────────────────────
+for i in 7 8 9; do
+  echo '{}' | bash "$HOOK" >/dev/null 2>&1
+done
+SECOND_REINJECT=$(echo '{}' | bash "$HOOK" 2>/dev/null)
+if [ -z "$SECOND_REINJECT" ]; then
+  fail "T9: no reinjection at 2x threshold (invocation 10)"
+fi
+
+# ── Test 10: different session ID = independent counter ──────────
+export CLAUDE_SESSION_ID="test-other-session"
+ISOLATED_OUT=$(echo '{}' | bash "$HOOK" 2>/dev/null)
+if [ -n "$ISOLATED_OUT" ]; then
+  fail "T10: different session should start at count 1, not trigger"
+fi
+
+# ── Test 11: .gitignore auto-created ─────────────────────────────
+if [ ! -f .claude/audit/.gitignore ]; then
+  fail "T11: .gitignore not auto-created"
+fi
+
+# ── Test 12: counter file contains valid number ──────────────────
+COUNTER_FILE=".claude/audit/.decay-counter-test-silent"
+if [ -f "$COUNTER_FILE" ]; then
+  VAL=$(cat "$COUNTER_FILE")
+  case "$VAL" in
+    ''|*[!0-9]*) fail "T12: counter file contains non-numeric: '$VAL'" ;;
+    *) ;; # ok
+  esac
+else
+  fail "T12: counter file not created"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────
+if [ "$FAILED" -gt 0 ]; then
+  echo ""
+  echo "check-decay-counter: $FAILED assertion(s) failed"
+  exit 1
+fi
+
+echo "check-decay-counter: 12 assertions passed"
+exit 0

--- a/tests/hooks/check-decay-counter.test.sh
+++ b/tests/hooks/check-decay-counter.test.sh
@@ -120,16 +120,27 @@ if [ ! -f .claude/audit/.gitignore ]; then
   fail "T11: .gitignore not auto-created"
 fi
 
-# ── Test 12: counter file contains valid number ──────────────────
-COUNTER_FILE=".claude/audit/.decay-counter-test-silent"
+# ── Test 12: backlog goal reminder included when .project/backlog.md exists ─
+rm -rf .claude 2>/dev/null
+export CLAUDE_SESSION_ID="test-backlog-goal"
+export DECAY_REINJECT_INTERVAL=1
+mkdir -p .project 2>/dev/null
+printf '%s\n%s\n' "- Deploy trading bot MVP" "- Setup monitoring" > .project/backlog.md
+GOAL_OUT=$(echo '{}' | bash "$HOOK" 2>/dev/null)
+if ! printf '%s' "$GOAL_OUT" | grep -q "Deploy trading bot MVP" 2>/dev/null; then
+  fail "T12: backlog goal reminder missing from reinjection"
+fi
+
+# ── Test 13: counter file contains valid number ──────────────────
+COUNTER_FILE=".claude/audit/.decay-counter-test-backlog-goal"
 if [ -f "$COUNTER_FILE" ]; then
   VAL=$(cat "$COUNTER_FILE")
   case "$VAL" in
-    ''|*[!0-9]*) fail "T12: counter file contains non-numeric: '$VAL'" ;;
+    ''|*[!0-9]*) fail "T13: counter file contains non-numeric: '$VAL'" ;;
     *) ;; # ok
   esac
 else
-  fail "T12: counter file not created"
+  fail "T13: counter file not created"
 fi
 
 # ── Summary ───────────────────────────────────────────────────────
@@ -139,5 +150,5 @@ if [ "$FAILED" -gt 0 ]; then
   exit 1
 fi
 
-echo "check-decay-counter: 12 assertions passed"
+echo "check-decay-counter: 13 assertions passed"
 exit 0

--- a/tests/hooks/check-loop-breaker.test.sh
+++ b/tests/hooks/check-loop-breaker.test.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Tests for templates/hooks/check-loop-breaker.sh (v8 item 3.1)
+#
+# Verifies:
+#   1. Exits 0 on every input variant (exit-0 guarantee)
+#   2. No warning for first/second edit of same file
+#   3. Warning emitted at 3rd edit of same file
+#   4. Escalation emitted at 5th edit
+#   5. Different files don't trigger each other
+#   6. Window rolling prevents unbounded ledger growth
+#   7. Handles empty/malformed input gracefully
+
+set +e
+
+HOOK="$(cd "$(dirname "$0")/../.." && pwd)/templates/hooks/check-loop-breaker.sh"
+if [ ! -x "$HOOK" ]; then
+  echo "  FAIL: hook not executable at $HOOK"
+  exit 1
+fi
+
+TMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t idea-factory 2>/dev/null)
+if [ -z "$TMPDIR" ] || [ ! -d "$TMPDIR" ]; then
+  echo "  FAIL: could not create temp directory"
+  exit 1
+fi
+trap 'rm -rf "$TMPDIR"' EXIT
+cd "$TMPDIR" || exit 1
+
+FAILED=0
+
+fail() {
+  echo "  FAIL: $1"
+  FAILED=$((FAILED + 1))
+}
+
+assert_eq() {
+  [ "$1" = "$2" ] || fail "$3 — expected '$2', got '$1'"
+}
+
+# ── Shared config ────────────────────────────────────────────────
+export CLAUDE_AUDIT_DIR=".claude/audit"
+export CLAUDE_SESSION_ID="test-loop"
+export LOOP_WARN_THRESHOLD=3
+export LOOP_ESCALATE_THRESHOLD=5
+export LOOP_WINDOW_SIZE=15
+
+make_payload() {
+  printf '{"tool_input":{"file_path":"%s"}}' "$1"
+}
+
+# ── Test 1: exit 0 on empty stdin ────────────────────────────────
+echo '' | bash "$HOOK"
+RC=$?
+assert_eq "$RC" "0" "T1: exit 0 for empty stdin"
+
+# ── Test 2: exit 0 on malformed JSON ────────────────────────────
+echo 'not json' | bash "$HOOK"
+RC=$?
+assert_eq "$RC" "0" "T2: exit 0 for malformed JSON"
+
+# ── Test 3: exit 0 on missing file_path ──────────────────────────
+echo '{"tool_input":{}}' | bash "$HOOK"
+RC=$?
+assert_eq "$RC" "0" "T3: exit 0 for missing file_path"
+
+# ── Test 4: no warning on 1st and 2nd edit ───────────────────────
+rm -rf .claude 2>/dev/null
+OUT1=$(make_payload "/src/app.ts" | bash "$HOOK" 2>/dev/null)
+assert_eq "$?" "0" "T4a: exit 0 on 1st edit"
+if [ -n "$OUT1" ]; then
+  fail "T4a: output on 1st edit"
+fi
+
+OUT2=$(make_payload "/src/app.ts" | bash "$HOOK" 2>/dev/null)
+assert_eq "$?" "0" "T4b: exit 0 on 2nd edit"
+if [ -n "$OUT2" ]; then
+  fail "T4b: output on 2nd edit"
+fi
+
+# ── Test 5: warning on 3rd edit ──────────────────────────────────
+OUT3=$(make_payload "/src/app.ts" | bash "$HOOK" 2>/dev/null)
+assert_eq "$?" "0" "T5: exit 0 on 3rd edit"
+if [ -z "$OUT3" ]; then
+  fail "T5: no warning on 3rd edit"
+fi
+if ! printf '%s' "$OUT3" | grep -q "WARNING" 2>/dev/null; then
+  fail "T5: WARNING keyword missing"
+fi
+
+# ── Test 6: still warning on 4th edit ────────────────────────────
+OUT4=$(make_payload "/src/app.ts" | bash "$HOOK" 2>/dev/null)
+assert_eq "$?" "0" "T6: exit 0 on 4th edit"
+if [ -z "$OUT4" ]; then
+  fail "T6: no warning on 4th edit"
+fi
+
+# ── Test 7: escalation on 5th edit ───────────────────────────────
+OUT5=$(make_payload "/src/app.ts" | bash "$HOOK" 2>/dev/null)
+assert_eq "$?" "0" "T7: exit 0 on 5th edit"
+if [ -z "$OUT5" ]; then
+  fail "T7: no output on 5th edit"
+fi
+if ! printf '%s' "$OUT5" | grep -q "ESCALATE" 2>/dev/null; then
+  fail "T7: ESCALATE keyword missing on 5th edit"
+fi
+
+# ── Test 8: different file doesn't trigger ───────────────────────
+# Reset session
+export CLAUDE_SESSION_ID="test-loop-isolated"
+rm -rf .claude 2>/dev/null
+
+make_payload "/src/a.ts" | bash "$HOOK" >/dev/null 2>&1
+make_payload "/src/b.ts" | bash "$HOOK" >/dev/null 2>&1
+OUT_DIFF=$(make_payload "/src/c.ts" | bash "$HOOK" 2>/dev/null)
+assert_eq "$?" "0" "T8: exit 0"
+if [ -n "$OUT_DIFF" ]; then
+  fail "T8: warning triggered for 3 different files"
+fi
+
+# ── Test 9: window rolling prevents unbounded growth ─────────────
+export CLAUDE_SESSION_ID="test-loop-window"
+export LOOP_WINDOW_SIZE=5
+rm -rf .claude 2>/dev/null
+
+# Write 10 entries for different files, then check ledger size
+for i in $(seq 1 10); do
+  make_payload "/src/file${i}.ts" | bash "$HOOK" >/dev/null 2>&1
+done
+
+LEDGER=".claude/audit/.loop-ledger-test-loop-window"
+if [ -f "$LEDGER" ]; then
+  LINES=$(wc -l < "$LEDGER" | tr -d ' ')
+  if [ "$LINES" -gt 5 ]; then
+    fail "T9: ledger has $LINES lines, expected <= 5 (window size)"
+  fi
+else
+  fail "T9: ledger file not created"
+fi
+
+# ── Test 10: .gitignore auto-created ─────────────────────────────
+if [ ! -f .claude/audit/.gitignore ]; then
+  fail "T10: .gitignore not auto-created"
+fi
+
+# ── Test 11: audit JSONL created on escalation ───────────────────
+export CLAUDE_SESSION_ID="test-loop-audit"
+rm -rf .claude 2>/dev/null
+for i in $(seq 1 5); do
+  make_payload "/src/audit-test.ts" | bash "$HOOK" >/dev/null 2>&1
+done
+TODAY=$(date +%Y-%m-%d)
+AUDIT_LOG=".claude/audit/loop-breaker-$TODAY.jsonl"
+if [ -f "$AUDIT_LOG" ]; then
+  python3 -c "
+import json
+with open('$AUDIT_LOG') as f:
+    for line in f:
+        if line.strip():
+            d = json.loads(line)
+            assert d['level'] == 'escalate', f'expected escalate, got {d[\"level\"]}'
+            assert d['hits'] >= 5, f'expected hits>=5, got {d[\"hits\"]}'
+  " 2>/dev/null || fail "T11: audit JSONL invalid or wrong content"
+else
+  fail "T11: audit JSONL not created on escalation"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────
+if [ "$FAILED" -gt 0 ]; then
+  echo ""
+  echo "check-loop-breaker: $FAILED assertion(s) failed"
+  exit 1
+fi
+
+echo "check-loop-breaker: 11 assertions passed"
+exit 0

--- a/tests/hooks/stop-learning-capture.test.sh
+++ b/tests/hooks/stop-learning-capture.test.sh
@@ -53,8 +53,9 @@ export CLAUDE_AUDIT_DIR=".claude/audit"
 mkdir -p "$CLAUDE_AUDIT_DIR"
 
 # Create only 5 audit entries (below threshold of 20)
+TODAY=$(date +%Y-%m-%d)
 for i in $(seq 1 5); do
-  echo '{"ts":"test","cmd":"ls"}' >> "$CLAUDE_AUDIT_DIR/$(date +%Y-%m-%d).jsonl"
+  echo '{"ts":"test","cmd":"ls"}' >> "$CLAUDE_AUDIT_DIR/$TODAY.jsonl"
 done
 
 OUT=$(echo '{}' | bash "$HOOK" 2>/dev/null)

--- a/tests/hooks/stop-learning-capture.test.sh
+++ b/tests/hooks/stop-learning-capture.test.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Tests for templates/hooks/stop-learning-capture.sh (v8 item 2.4)
+#
+# Verifies:
+#   1. Exits 0 always (exit-0 guarantee)
+#   2. Silent when no learning layer dirs exist
+#   3. Silent when session is too small (< 20 audit entries)
+#   4. Prompts when learning layer + substantial activity
+#   5. Prompts when decisions.md changed in recent commit
+#   6. Contains all 4 learning categories in output
+
+set +e
+
+HOOK="$(cd "$(dirname "$0")/../.." && pwd)/templates/hooks/stop-learning-capture.sh"
+if [ ! -x "$HOOK" ]; then
+  echo "  FAIL: hook not executable at $HOOK"
+  exit 1
+fi
+
+TMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t idea-factory 2>/dev/null)
+if [ -z "$TMPDIR" ] || [ ! -d "$TMPDIR" ]; then
+  echo "  FAIL: could not create temp directory"
+  exit 1
+fi
+trap 'rm -rf "$TMPDIR"' EXIT
+cd "$TMPDIR" || exit 1
+
+FAILED=0
+
+fail() {
+  echo "  FAIL: $1"
+  FAILED=$((FAILED + 1))
+}
+
+assert_eq() {
+  [ "$1" = "$2" ] || fail "$3 — expected '$2', got '$1'"
+}
+
+# ── Test 1: exit 0 with no learning layer ────────────────────────
+echo '{}' | bash "$HOOK"
+RC=$?
+assert_eq "$RC" "0" "T1: exit 0 with no learning layer"
+
+# ── Test 2: silent with no learning layer ────────────────────────
+OUT=$(echo '{}' | bash "$HOOK" 2>/dev/null)
+if [ -n "$OUT" ]; then
+  fail "T2: output when no learning layer dirs exist"
+fi
+
+# ── Test 3: silent when learning layer exists but session too small ─
+mkdir -p docs/research docs/field-reports
+export CLAUDE_AUDIT_DIR=".claude/audit"
+mkdir -p "$CLAUDE_AUDIT_DIR"
+
+# Create only 5 audit entries (below threshold of 20)
+for i in $(seq 1 5); do
+  echo '{"ts":"test","cmd":"ls"}' >> "$CLAUDE_AUDIT_DIR/$(date +%Y-%m-%d).jsonl"
+done
+
+OUT=$(echo '{}' | bash "$HOOK" 2>/dev/null)
+RC=$?
+assert_eq "$RC" "0" "T3: exit 0 with small session"
+if [ -n "$OUT" ]; then
+  fail "T3: output when session too small (5 entries)"
+fi
+
+# ── Test 4: prompts with substantial activity (20+ entries) ──────
+TODAY=$(date +%Y-%m-%d)
+for i in $(seq 6 25); do
+  echo '{"ts":"test","cmd":"ls"}' >> "$CLAUDE_AUDIT_DIR/$TODAY.jsonl"
+done
+
+OUT=$(echo '{}' | bash "$HOOK" 2>/dev/null)
+RC=$?
+assert_eq "$RC" "0" "T4: exit 0 with substantial session"
+if [ -z "$OUT" ]; then
+  fail "T4: no prompt with 25 audit entries"
+fi
+
+# ── Test 5: contains SESSION LEARNING CAPTURE header ─────────────
+if ! printf '%s' "$OUT" | grep -q "SESSION LEARNING CAPTURE" 2>/dev/null; then
+  fail "T5: SESSION LEARNING CAPTURE header missing"
+fi
+
+# ── Test 6: contains all 4 learning categories ──────────────────
+if ! printf '%s' "$OUT" | grep -q "gap" 2>/dev/null; then
+  fail "T6a: gap category missing"
+fi
+if ! printf '%s' "$OUT" | grep -q "docs/research/" 2>/dev/null; then
+  fail "T6b: research path missing"
+fi
+if ! printf '%s' "$OUT" | grep -q "docs/field-reports/" 2>/dev/null; then
+  fail "T6c: field-reports path missing"
+fi
+if ! printf '%s' "$OUT" | grep -q "decisions.md" 2>/dev/null; then
+  fail "T6d: decisions.md reference missing"
+fi
+
+# ── Test 7: exit 0 on malformed input ────────────────────────────
+echo 'not json' | bash "$HOOK"
+RC=$?
+assert_eq "$RC" "0" "T7: exit 0 on malformed input"
+
+# ── Test 8: silent when only docs/research exists (no field-reports) ──
+rm -rf docs/field-reports .claude
+mkdir -p .claude/audit
+# Small session → should be silent
+for i in $(seq 1 5); do
+  echo '{"ts":"test"}' >> ".claude/audit/$TODAY.jsonl"
+done
+OUT=$(echo '{}' | bash "$HOOK" 2>/dev/null)
+if [ -n "$OUT" ]; then
+  fail "T8: should be silent with small session even with docs/research"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────
+if [ "$FAILED" -gt 0 ]; then
+  echo ""
+  echo "stop-learning-capture: $FAILED assertion(s) failed"
+  exit 1
+fi
+
+echo "stop-learning-capture: 8 assertions passed"
+exit 0


### PR DESCRIPTION
## Summary

v8 Wave 1 핵심 항목 3개 구현 — 사용자가 보고한 두 가지 문제(자의적 작업 중단, 무한 루프)의 시스템 해결 + 학습 자동 캡처.

### 4.1 Instruction decay counter + anti-quit [HIGH]
- `templates/hooks/check-decay-counter.sh` — PreToolUse 훅
- 40회 도구 호출마다 핵심 규칙 재주입 (anti-quit, circuit breaker, context hygiene)
- Khare decay curve (준수율 20-60% 붕괴) 대응
- 12 assertions

### 3.1 Fix-loop circuit breaker [HIGH]
- `templates/hooks/check-loop-breaker.sh` — PostToolUse Write|Edit 훅
- 세션별 rolling window (15 entries)로 같은 파일 반복 편집 감지
- 3회 → WARNING, 5회 → ESCALATE + audit JSONL
- 11 assertions

### 2.4 Session-end learning capture [HIGH]
- `templates/hooks/stop-learning-capture.sh` — Stop 훅
- 학습층 존재 + 20+ audit 엔트리 시 4가지 카테고리 기록 제안
- false positive 방지를 위한 활동량 임계값
- 8 assertions

### 함께 변경
- `templates/CLAUDE.md.tmpl` — anti-quit + 3회 실패 중단 prose rule
- `templates/settings.json` — 3개 훅 등록
- `docs/plans/v8-backlog.md` — 2.4, 3.1, 4.1 상태 done

## Test plan
- [x] check-decay-counter: 12 assertions passed
- [x] check-loop-breaker: 11 assertions passed
- [x] stop-learning-capture: 8 assertions passed
- [x] 기존 훅 회귀 없음 (전체 63 assertions passed)

Closes #13
Closes #15

🤖 Generated by Claude Code [claude-opus-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stronger session quality controls: stop/escalate after repeated failures, anti-quit protections, loop-detection with warning/escalation for repeated edits, and periodic reinjection of guidance during long sessions

* **Documentation**
  * Backlog updated to mark related quality-control and decay items done and clarify failure/decay symptoms

* **Tests**
  * Added end-to-end tests for decay reinjection, loop detection, and learning-capture prompts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->