### PR TITLE
feat: Skills 2.0 포맷 마이그레이션 (#22)

### DIFF
--- a/skills/start-company/SKILL.md
+++ b/skills/start-company/SKILL.md
@@ -3,6 +3,13 @@ name: start-company
 description: "Give a one-line idea, get a virtual startup that builds your MVP autonomously. Use when you want to create a new product from scratch."
 argument-hint: "[your idea in one line] — passed as $ARGUMENTS"
 user_invocable: true
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Task
+disable-model-invocation: false
 ---
 
 # idea-factory
@@ -20,288 +27,43 @@ Build a virtual startup and deliver a working MVP.
 5. **Heal, Don't Repeat**: If something fails twice, find the root cause.
 6. **Model Strategy**: Sonnet default. Opus for architecture/RCA/deep analysis.
 
-## Execution Flow
+## Execution Flow Overview
 
-### STEP 1 — Analyze (parallel agents)
+Seven phases run in sequence. Full per-phase detail is in `phases.md`.
 
-Launch two agents in parallel:
+1. **ANALYZE** — Two parallel agents (analyst + architect, both opus) dissect the idea
+2. **SCAFFOLD** — Create project from `~/.claude/templates/company/` (26 items)
+3. **KICKOFF** — Ask CEO 3–5 plain-language questions; fill CLAUDE.md + PRD + essence.md
+4. **BUILD MVP** — Generate `.omc/prd.json` stories; start `/oh-my-claudecode:ralph`
+5. **VALIDATE** — 4 isolated reviewers (architect / critic / code-reviewer / qa-tester) per gate
+6. **HARDEN** — Real APIs, tests, security audit, protected-files, quality-baseline
+7. **SHIP** — GitHub + 5-stage PR pipeline + 6-gate deploy consensus + retro
 
-**Agent 1** (analyst, opus): Analyze the idea.
-- Service name, folder name, service type (SaaS/O2O/commerce/content/data/internal-tool), project type (web-app/cron-bot/trading/payment)
-- Core problem, target users, competitors, differentiation
-- Risk factors (tech, legal, business)
-- Output: structured analysis
+For per-phase step-by-step instructions, see `phases.md`.
+For agent role definitions and assignment rules, see `agents.md`.
 
-**Agent 2** (architect, opus): Technical architecture.
-- Required roles (minimum 2-3 people)
-- Tech stack candidates (2-3 options)
-- Project structure recommendation
-- Output: structured recommendation
+## Critical Invariants (apply across all phases)
 
-After completing STEP 1, proceed immediately to STEP 2.
+### CLAUDE.md Size Rule
+- Generated CLAUDE.md MUST stay under 80 lines (leaves room for growth)
+- NEVER replace CLAUDE.md with a single `@AGENTS.md` pointer
+- Use progressive disclosure: details in separate files, pointers in CLAUDE.md
+- Reference: https://www.humanlayer.dev/blog/writing-a-good-claude-md
 
-### STEP 2 — Scaffold
+### Fix-Loop Circuit Breaker
+- If any story fails the same way 3 times → STOP and escalate to CEO
+- After 3 failures: write diagnosis to `.project/decisions.md` and flag to CEO
+- This overrides "Heal, Don't Repeat" — healing has a budget
 
-Read templates from `~/.claude/templates/company/`.
-Create project at `~/{folder-name}/`:
+### Fresh Context Isolation (gates)
+- Every gate reviewer MUST run with `isolation: "worktree"`
+- Reason: same-context evaluation always inflates quality ("Evaluator Leniency")
 
-1. `CLAUDE.md` — choose template based on project type:
-   - **cron-bot/trading**: from `templates/cron-bot/CLAUDE.md.tmpl` (no UI/Playwright, yes reliability/monitoring rules)
-   - **web-app/payment**: from `templates/CLAUDE.md.tmpl`
-   Replace `{{variables}}`.
-   **CRITICAL**: CLAUDE.md MUST be a full file (30-80 lines) with project rules, quality gates,
-   and AI regression prevention. NEVER replace it with a single `@AGENTS.md` pointer.
-   If variable substitution fails, copy the template as-is and fill manually in STEP 3.
-   Verify after creation: `wc -l CLAUDE.md` must be >= 30 lines.
-2. `.claude/agents/` — from `templates/agents/`, minimum team only
-   Agent templates should include: role definition, key responsibilities,
-   "situations where this agent MUST speak up" (e.g., architect must flag
-   when protected files are changed), and inter-agent collaboration rules.
-   Reference: market-dashboard-v5 agents are 90+ lines each with career anchors
-   and project-specific context. Aim for at least 50 lines per agent.
-3. `.claude/hooks/` — copy from `templates/hooks/`
-4. `.claude/settings.json` — merge base `templates/settings.json` with type-specific deny-list:
-   `bash scripts/merge-settings.sh <project-type>` where project-type maps from service type:
-   - SaaS/content/internal-tool → `web-app`
-   - O2O/commerce → `payment`
-   - data → `cron-bot`
-   - trading (if detected in idea keywords) → `trading`
-   Write the merged output to `.claude/settings.json`.
-5. `.project/essence.md` — empty, filled in STEP 3
-6. `.project/PRD.md` — empty, filled in STEP 3
-7. `.project/decisions.md` — initialized with creation ADR
-8. `.project/backlog.md` — empty
-9. `.github/workflows/ci.yml` — from `templates/.github/workflows/ci.yml`
-10. `.github/workflows/label-pr.yml` — from `templates/.github/workflows/label-pr.yml`
-11. `.github/labeler.yml` — from `templates/.github/labeler.yml`
-12. `vercel.json` — from `templates/vercel.json` (preview 배포 비활성화, production만).
-    **Vercel 연결 후 필수 설정**: Dashboard > Settings > Git > "Production Branch" = `main`, Preview Deployments = OFF
-13. `.coderabbit.yaml` — from `templates/.coderabbit.yaml`
-14. `src/CONTRACT.md` — from `templates/documents/CONTRACT.md.tmpl`, replace `{{FEATURE_NAME}}` with service name
-15. `.project/handoff/` — empty directory for phase transition documents (template: `templates/documents/handoff.md.tmpl`)
-16. `scripts/create-pr.sh` — from `templates/scripts/create-pr.sh` (5-stage PR pipeline)
-17. `scripts/pre-deploy-consensus.sh` — from `templates/scripts/pre-deploy-consensus.sh` (6-gate deploy consensus)
-18. `scripts/review-summary.sh` — from `templates/scripts/review-summary.sh` (review summary auto-post)
-19. `scripts/run-architect.sh` — from `templates/scripts/run-architect.sh` (protected file review)
-20. `scripts/update-project-docs.sh` — from `templates/scripts/update-project-docs.sh` (auto doc update on PR)
-21. `.protected-files` — empty, filled after Phase 1 (files requiring architect review)
-22. `.githooks/pre-push` — from `templates/.githooks/pre-push` (stale review warning)
-23. `.github/workflows/token-health.yml` — from `templates/.github/workflows/token-health.yml` (weekly token check)
-24. `.project/quality-baseline.md` — empty, generated after Phase 2 (from `templates/documents/quality-baseline.md.tmpl`)
-25. **cron-bot/trading only** — additional files from `templates/cron-bot/scripts/`:
-    - `scripts/backtest.sh` — backtest runner (date range + config)
-    - `scripts/rollback.sh` — version rollback with audit logging
-    - `scripts/health-check.sh` — JSON health status reporter
-    - `templates/workflows/tuning-session.md` → `.project/tuning-protocol.md` (parameter tuning protocol)
-    - `.omc/experiments/` directory with README from `templates/experiments/README.md`
-26. `git init` + `git config core.hooksPath .githooks` + initial commit
-
-**Template variable reference**:
-- `{{SERVICE_NAME}}` — service name from analysis
-- `{{SERVICE_TYPE}}` — SaaS, O2O, commerce, etc.
-- `{{MISSION}}` — one-line description
-- `{{PROBLEM}}` — core problem
-- `{{TARGET}}` — target users
-- `{{DIFFERENTIATOR}}` — what makes it different
-- `{{TECH_STACK}}` — chosen tech stack (filled after kickoff)
-- `{{TEAM_TABLE}}` — markdown table rows for team roster, e.g. `| PM | pm | claude-sonnet-4-6 |`
-
-After completing STEP 2, proceed immediately to STEP 3.
-
-### STEP 3 — Kickoff
-
-Ask CEO 3-5 questions using AskUserQuestion. Rules:
-- NO technical jargon
-- Present choices as A/B/C options
-- Topics: design feel, MVP scope, platform, revenue model
-- DO NOT ask about tech stack — team decides
-
-With answers:
-1. Fill `CLAUDE.md` Tech Stack section
-2. Write `.project/PRD.md` with 3-5 core features
-3. Write `.project/essence.md`:
-   - One-line definition
-   - Why this exists (the problem it solves)
-   - Wow factor (what makes users go "wow")
-   - Differentiator (what competitors don't do)
-   - Key metric (one number that matters)
-4. Record decisions in `.project/decisions.md`
-
-### STEP 4 — Autonomous Build (Ralph Loop)
-
-Generate `.omc/prd.json` with stories in this order:
-
-```
-Phase 1 — MVP (mock data, local only)
-  MVP-001: Project init (packages, routing, layout)
-  MVP-002: Main screen with mock data
-  MVP-003: Core user flow #1
-  MVP-004: Core user flow #2 (if needed)
-  VALIDATE-001: MVP Gate (gate: true)
-
-  HANDOFF-MVP: Write MVP→Harden handoff document (see template)
-
-Phase 2 — Harden (real APIs, tests, security)
-  HARDEN-001: Replace mock with real data
-  HARDEN-002: Error handling + loading states
-  HARDEN-003: Tests
-  HARDEN-004: Security audit
-  HARDEN-005: Generate .protected-files list + run-architect.sh integration
-  HARDEN-006: Generate quality-baseline.md (ratchet rules — quality never goes down)
-  VALIDATE-002: Production Gate (gate: true)
-
-  HANDOFF-HARDEN: Write Harden→Ship handoff document (see template)
-
-Phase 3 — Ship
-  SHIP-001: gh repo create → bash scripts/setup-github.sh (branch protection + labels)
-  SHIP-002: Full 5-stage PR pipeline — build → code-reviewer artifact check →
-            Codex Gate → create-pr.sh (issue linking + bot polling) → review-summary.sh
-  SHIP-003: Deploy with pre-deploy-consensus.sh (6 gates must pass) + smoke test + retro
-  SHIP-004: Set up .githooks/pre-push + `git config core.hooksPath .githooks`
-  SHIP-005: Run update-project-docs.sh for final doc sync
-```
-
-Then start `/oh-my-claudecode:ralph`.
-
-**Gate stories** trigger parallel independent reviews.
-
-> **CRITICAL: Fresh Context Isolation**
-> Every gate reviewer MUST run with `isolation: "worktree"` (a separate copy of the project).
-> Reason: Anthropic's research proves that an agent evaluating its own work in the same
-> context always inflates quality ("Evaluator Leniency"). Fresh context = honest evaluation.
-> Reference: https://www.anthropic.com/engineering/harness-design-long-running-apps
-
-> **CRITICAL: Defect-Detection FIRST, Scoring SECOND (if at all)**
-> Step 1: Always start with adversarial defect-detection framing ("find every flaw").
-> Step 2: Only AFTER defects are listed, optionally score on 4 axes in a FRESH context.
-> WHY: Scoring without prior defect detection triggers "Rubric Gaming" — the AI optimizes
-> for high scores instead of finding problems. But scoring CAN work when the evaluator
-> has already committed to a defect list (Anthropic used scoring with tuned criteria
-> and a separated evaluator). The key: defects first, scores second, never same context.
-
-Four reviewers run in parallel, each in isolated worktree:
-
-- `architect` (opus, isolation: worktree): Structure adversarial review.
-  Prompt framing: "You are a hostile tech lead reviewing a junior's PR. Find every
-  structural problem that will block Phase 2. List every shortcut, every missing
-  abstraction, every coupling that will cause pain later. Be brutal."
-
-- `critic` (opus, isolation: worktree): Essence adversarial review.
-  Prompt framing: "You are a competitor analyzing this product. List every reason
-  a user would abandon this within 30 seconds. Find every place where the product
-  drifts from its core 'Why' in essence.md. What would you mock if you saw this
-  at a demo day?"
-
-- `code-reviewer` (opus, isolation: worktree): Code quality review.
-  Task-invoke the `code-reviewer` subagent. Its definition is vendored at
-  `.claude/agents/code-reviewer.md` (scaffolded from idea-factory's
-  `templates/agents/code-reviewer.md` at project creation). It runs a 2-stage
-  review: Stage 1 = spec compliance (does it match PRD?), Stage 2 = code quality
-  (security, SOLID, logic, performance). Issues are severity-rated (CRITICAL/HIGH/
-  MEDIUM/LOW). Only CRITICAL and HIGH block the gate.
-  This agent already enforces "never approve your own authoring output."
-
-- `qa-tester` (sonnet, isolation: worktree, tools: Playwright MCP): Functional review.
-  Prompt framing: "You are a frustrated beta tester who wants to break this app.
-  Open the running app in Playwright. Click every button, fill every form, try every
-  edge case. For each broken or confusing interaction, write: what you did, what you
-  expected, what actually happened. Screenshots are evidence."
-  **Playwright MCP required**: qa-tester MUST open the actual running app in a browser
-  and interact with it. Code-only review is NOT sufficient. If the app isn't running,
-  start it first. Test real clicks, real navigation, real data display.
-
-Cross-model review (mandatory when Codex CLI available):
-- If Codex CLI is installed, MUST run Codex Gate on the diff.
-  This is NOT optional — Gate 1 proved ROI (caught 2 bugs Claude missed).
-- If Codex CLI is not installed, log a warning in gate-results and skip.
-- Track results in `.project/codex-gate-log.md` for ROI evaluation.
-
-Gate evaluation (two-pass):
-- **Pass 1 — Defect Hunt** (mandatory): Each reviewer outputs a **defect list** first.
-  No scores allowed in this pass. Pure adversarial problem-finding.
-- **Pass 2 — Structured Score** (optional, fresh context): After defect lists are committed,
-  a separate agent MAY score on 4 axes: Functionality / Essence Alignment / Code Quality / UX.
-  Hard threshold: if any axis < 6/10, auto-fail. This pass is useful for tracking progress
-  across iterations but is NOT required for gate passage.
-- **Gate result logging** (mandatory): Save ALL reviewer outputs (defect lists + optional scores)
-  to `.project/gate-results/VALIDATE-{NNN}.md`. This enables post-mortem analysis and QA tuning.
-- Gate passes when: total critical defects = 0 across all four Pass 1 reviewers
-- If any critical defect found → add fix stories before the gate and retry
-- If all pass → ask CEO "Is this the right direction?" then proceed
-- After qa-tester completes, run `scripts/validate-qa-evidence.sh` on the output.
-  If zero Playwright evidence → qa-tester must re-run with actual browser interaction.
-
-Why two-pass works (for people reading this on GitHub):
-- Pass 1 alone: "Find every flaw as a hostile reviewer" → AI finds 5-15 real issues
-- Scoring alone: "Rate this 1-10" → AI gives 9/10 and moves on (Evaluator Leniency)
-- Two-pass: defects are already committed before scoring begins, so the scorer can't ignore them
-- Anthropic used scoring successfully — but with separated evaluators and tuned criteria
-- The failure mode is scoring WITHOUT prior defect detection in the SAME context
-
-### Essence Verification (every story completion)
-
-After each story, ask these adversarial questions (NOT scores):
-1. "If a user described this app in one sentence, would it match essence.md? If not, what's the gap?"
-2. "Would a competitor look at this feature and say 'that's clever'? Or 'that's generic'?"
-3. "If we removed this feature entirely, would the core value proposition survive?"
-
-If any answer reveals drift → flag in backlog with specific description of the drift.
-If drift is severe (feature contradicts the "Why") → escalate to CEO with pivot options.
-
-> Why no scores: Numeric drift scores (e.g., "drift = 5/10") trigger the same Evaluator Leniency
-> as scoring code quality. The AI will always report low drift to keep moving. Adversarial questions
-> force concrete, specific answers that reveal real problems.
-
-### CEO Escalation (only these)
+### CEO Escalation (only these triggers)
 - Paid API keys, billing, account connections
 - Major pivot needed
 - Physical/legal/administrative help needed
 - Branding/policy decisions requiring CEO intent
-
-### Context Health Management (auto-compact + subagent isolation)
-- **60% Rule**: After every story, check context usage.
-  60% → `/compact Keep: essence, Phase, decisions, current story, bugs`
-  80% → checkpoint.md + warn CEO. 95% → STOP + new session.
-  NEVER let context reach 95% without compacting — degraded memory = garbage summary.
-- **Subagent Isolation**: Heavy work (tests, file search, code gen) → subagent.
-  Main session stays lightweight: direction, decisions, story management only.
-  Subagent returns summary, not raw output. This prevents context bloat.
-- **Checkpoint**: Every 10 stories or ~2 hours → `.project/checkpoint.md`
-- **Session Start**: CLAUDE.md includes 7-file read checklist for new sessions.
-- Reference: Anthropic "Context Reset with structured handoff" + /compact 60% rule
-  (https://www.mindstudio.ai/blog/claude-code-compact-command-context-management)
-
-### CLAUDE.md Size Rule (from HumanLayer research)
-- AI can follow ~150-200 instructions before compliance drops
-- Claude Code system prompt already uses ~50 of those
-- Generated CLAUDE.md MUST stay under 80 lines (leaves room for growth)
-- Use progressive disclosure: put details in separate files, pointers in CLAUDE.md
-- Reference: https://www.humanlayer.dev/blog/writing-a-good-claude-md
-
-### Fix-Loop Circuit Breaker (from Reddit/Stormy AI community)
-- If any story fails the same way 3 times → STOP and escalate
-- Do NOT let the agent enter an infinite fix-loop (burns tokens, produces garbage)
-- After 3 failures: write a diagnosis to `.project/decisions.md` and flag to CEO
-- This overrides "Heal, Don't Repeat" — healing has a budget
-
-### Ghost Bug Awareness
-- "Ghost Bugs" = code that looks perfect but fails in edge cases
-- Playwright testing (qa-tester) is the primary defense
-- After Phase 2 (Harden), add edge case scenarios to Playwright tests:
-  empty inputs, special characters, network timeouts, rapid double-clicks
-
-### Quality Ratchet (from market-dashboard-v5, proven across 13 phases)
-- After Phase 2 (Harden), generate `.project/quality-baseline.md`
-- Rule: quality metrics can only go UP, never DOWN
-- Covers: build status, test count, data accuracy, UI states, API fallback, deploy checklist
-- Every PR must not regress any baseline metric
-- If regression detected → block PR until fixed or CEO approves exception
-
-### Protected Files (architect review enforcement)
-- After Phase 1, identify core algorithm/business logic files → write to `.protected-files`
-- Any change to listed files triggers mandatory architect (opus) review
-- `run-architect.sh` generates review artifact; `create-pr.sh` verifies artifact exists and is fresh
-- Stale artifact (wrong commit hash) → PR blocked
 
 ### Never
 - Never ask CEO technical implementation questions
@@ -309,5 +71,5 @@ If drift is severe (feature contradicts the "Why") → escalate to CEO with pivo
 - Never deploy before VALIDATE gate passes
 - Never repeat the same failed approach twice
 - Never start coding without essence.md
-- Never let CLAUDE.md exceed 80 lines (use progressive disclosure instead)
+- Never let CLAUDE.md exceed 80 lines
 - Never let a fix-loop run more than 3 attempts on the same error

--- a/skills/start-company/agents.md
+++ b/skills/start-company/agents.md
@@ -1,0 +1,216 @@
+# start-company — Agent Role Definitions
+
+This file is loaded when `/start-company` is active. It defines every agent role used
+during the startup build process, their responsibilities, and which tasks they own.
+Execution phase details live in `phases.md`. The entry point is `SKILL.md`.
+
+---
+
+## Role Summary
+
+| Agent | Model | Phase | Primary Responsibility |
+|-------|-------|-------|----------------------|
+| analyst | opus | ANALYZE | Market/business analysis of the idea |
+| architect | opus | ANALYZE, VALIDATE, HARDEN | Technical architecture + structure review |
+| critic | opus | VALIDATE | Essence alignment adversarial review |
+| code-reviewer | opus | VALIDATE | Spec compliance + code quality review |
+| developer | sonnet | BUILD MVP, HARDEN | Feature implementation |
+| designer | sonnet | BUILD MVP | UI/UX design and component decisions |
+| pm | sonnet | BUILD MVP, HARDEN, SHIP | Story management, backlog, CEO interface |
+| qa-tester | sonnet | VALIDATE | Playwright-based functional testing |
+
+---
+
+## Agent Definitions
+
+### analyst (opus)
+
+**Phase**: ANALYZE (STEP 1, parallel with architect)
+
+**Responsibilities**:
+- Determine service name and folder name
+- Classify service type: SaaS / O2O / commerce / content / data / internal-tool
+- Classify project type: web-app / cron-bot / trading / payment
+- Identify core problem, target users, competitors, differentiation
+- Surface risk factors: tech, legal, business
+- Output: structured analysis report
+
+**Output format**: structured analysis (not prose) — service name, type, problem, users, risks, differentiation.
+
+**Must speak up when**:
+- Idea has legal/regulatory risks (financial, medical, user data)
+- Target market is too narrow to sustain a business
+- Idea requires hardware or physical-world dependencies that AI cannot handle
+
+---
+
+### architect (opus)
+
+**Phase**: ANALYZE (STEP 1), VALIDATE (gate reviewer), HARDEN (protected file review)
+
+**Responsibilities**:
+
+During ANALYZE:
+- Determine minimum required team roles (2-3 people)
+- Propose 2-3 tech stack options with tradeoffs
+- Recommend project structure
+- Output: structured recommendation
+
+During VALIDATE (gate reviewer, isolated worktree):
+- Adversarial structural review — find every problem that will block Phase 2
+- Framing: "You are a hostile tech lead reviewing a junior's PR. Find every structural
+  problem. List every shortcut, missing abstraction, and coupling that will cause pain later."
+- Outputs defect list only in Pass 1. No scores in Pass 1.
+
+During HARDEN:
+- Review any changes to `.protected-files` entries
+- `run-architect.sh` generates review artifact; verify artifact is fresh (correct commit hash)
+
+**Must speak up when**:
+- A protected file is modified without architect review
+- CLAUDE.md exceeds 80 lines
+- Tech debt accumulates that will block deployment
+
+---
+
+### critic (opus)
+
+**Phase**: VALIDATE (gate reviewer, isolated worktree)
+
+**Responsibilities**:
+- Essence adversarial review — find every place the product drifts from its "Why"
+- Framing: "You are a competitor analyzing this product. List every reason a user would
+  abandon this within 30 seconds. Find every place where the product drifts from its core
+  'Why' in essence.md. What would you mock if you saw this at a demo day?"
+- Outputs defect list only in Pass 1. No scores in Pass 1.
+
+**Must speak up when**:
+- A feature contradicts the one-line definition in essence.md
+- The "wow factor" has been removed or diluted
+- The product looks like a generic clone of a competitor
+
+---
+
+### code-reviewer (opus)
+
+**Phase**: VALIDATE (gate reviewer, isolated worktree)
+
+**Responsibilities**:
+- 2-stage review: Stage 1 = spec compliance (does it match PRD?), Stage 2 = code quality
+- Severity rating: CRITICAL / HIGH / MEDIUM / LOW
+- Only CRITICAL and HIGH block the gate
+- Definition vendored at `.claude/agents/code-reviewer.md` in the downstream project
+- Enforces: "never approve your own authoring output"
+
+**Must speak up when**:
+- CRITICAL or HIGH severity issues found
+- PRD features are missing from implementation
+- Security vulnerabilities detected (injection, unvalidated input, exposed secrets)
+
+---
+
+### developer (sonnet)
+
+**Phase**: BUILD MVP (STEP 4), HARDEN (STEP 6)
+
+**Responsibilities**:
+- Implement stories from `.omc/prd.json`
+- Mock data first during MVP phase; real APIs only during Harden
+- Heavy work (tests, file search, large code gen) → delegate to subagent to protect main context
+- Report summary back to main session, not raw output
+
+**Must speak up when**:
+- Same error occurs 3 times (fix-loop circuit breaker — escalate immediately)
+- Implementation requires a paid API key not yet provided
+- Scope of a story is ambiguous enough to risk building the wrong thing
+
+---
+
+### designer (sonnet)
+
+**Phase**: BUILD MVP (STEP 4)
+
+**Responsibilities**:
+- UI/UX design decisions based on CEO's design feel answer from KICKOFF
+- Component and layout choices
+- Ensures the "wow factor" from essence.md is visually represented
+- Does NOT ask CEO about tech choices (CSS framework, component library, etc.)
+
+**Must speak up when**:
+- Design drift detected — UI no longer reflects essence.md wow factor
+- Accessibility issues that would block mainstream users
+
+---
+
+### pm (sonnet)
+
+**Phase**: BUILD MVP (STEP 4), HARDEN (STEP 6), SHIP (STEP 7)
+
+**Responsibilities**:
+- Manage the story backlog in `.project/backlog.md`
+- Translate CEO answers from KICKOFF into `.project/PRD.md` features
+- Write `.project/essence.md` based on CEO intent
+- Flag essence drift discovered during story completion (adversarial questions)
+- Prepare handoff documents between phases
+- Interface with CEO: plain language only, A/B/C choices, no jargon
+- Log all decisions to `.project/decisions.md`
+
+**Must speak up when**:
+- A story is added that does not serve the core "Why" in essence.md
+- CEO needs to be escalated to (API keys, pivot, legal, branding decisions)
+- Context reaches 60% (trigger `/compact`)
+
+---
+
+### qa-tester (sonnet + Playwright MCP)
+
+**Phase**: VALIDATE (gate reviewer, isolated worktree)
+
+**Responsibilities**:
+- Functional review via actual browser interaction — NOT code review
+- Opens the running app in Playwright, clicks every button, fills every form
+- Framing: "You are a frustrated beta tester who wants to break this app. For each broken
+  or confusing interaction, write: what you did, what you expected, what actually happened.
+  Screenshots are evidence."
+- After completing, output is validated by `scripts/validate-qa-evidence.sh`
+- If zero Playwright evidence found → must re-run with actual browser interaction
+
+**Playwright MCP required**: qa-tester MUST open the actual running app in a browser.
+Code-only review is NOT sufficient. If the app isn't running, start it first.
+
+**Must speak up when**:
+- App cannot be started (blocks the entire gate)
+- A core user flow produces an error or unexpected result
+- UI is confusing enough that a real user would abandon within 30 seconds
+
+---
+
+## Agent Assignment Quick Reference
+
+| Task | Agent | Model |
+|------|-------|-------|
+| Market analysis | analyst | opus |
+| Tech stack recommendation | architect | opus |
+| Project scaffold | (executor — no named agent) | — |
+| CEO questions / kickoff | pm | sonnet |
+| PRD + essence.md authoring | pm | sonnet |
+| Feature implementation | developer | sonnet |
+| UI/component decisions | designer | sonnet |
+| Gate: structural review | architect | opus |
+| Gate: essence review | critic | opus |
+| Gate: code quality | code-reviewer | opus |
+| Gate: functional/browser | qa-tester | sonnet |
+| Protected file review | architect | opus |
+| Backlog management | pm | sonnet |
+| CEO escalation interface | pm | sonnet |
+
+---
+
+## Inter-Agent Collaboration Rules
+
+1. Agents run in **isolated worktrees** during gate reviews — no shared context with the authoring agent.
+2. Gate reviewers output **defect lists first** (Pass 1). Scores are optional and only in a separate fresh context (Pass 2).
+3. The `developer` and `designer` agents delegate heavy work to subagents; the main session receives summaries only.
+4. The `pm` is the sole interface to CEO — no other agent asks the CEO questions directly.
+5. The `architect` must be invoked any time a file listed in `.protected-files` is modified.
+6. All agents must respect the fix-loop circuit breaker: if the same error occurs 3 times, escalate to CEO via `pm` — do not retry a fourth time.

--- a/skills/start-company/phases.md
+++ b/skills/start-company/phases.md
@@ -1,0 +1,305 @@
+# start-company — Phase Detail
+
+This file is loaded when `/start-company` is active. It contains the full step-by-step
+execution instructions for all seven phases. The lightweight entry point and critical
+invariants live in `SKILL.md`. Agent role definitions live in `agents.md`.
+
+---
+
+## STEP 1 — Analyze (parallel agents)
+
+Launch two agents in parallel:
+
+**Agent 1** (analyst, opus): Analyze the idea.
+- Service name, folder name, service type (SaaS/O2O/commerce/content/data/internal-tool), project type (web-app/cron-bot/trading/payment)
+- Core problem, target users, competitors, differentiation
+- Risk factors (tech, legal, business)
+- Output: structured analysis
+
+**Agent 2** (architect, opus): Technical architecture.
+- Required roles (minimum 2-3 people)
+- Tech stack candidates (2-3 options)
+- Project structure recommendation
+- Output: structured recommendation
+
+After completing STEP 1, proceed immediately to STEP 2.
+
+---
+
+## STEP 2 — Scaffold
+
+Read templates from `~/.claude/templates/company/`.
+Create project at `~/{folder-name}/`:
+
+1. `CLAUDE.md` — choose template based on project type:
+   - **cron-bot/trading**: from `templates/cron-bot/CLAUDE.md.tmpl` (no UI/Playwright, yes reliability/monitoring rules)
+   - **web-app/payment**: from `templates/CLAUDE.md.tmpl`
+   Replace `{{variables}}`.
+   **CRITICAL**: CLAUDE.md MUST be a full file (30-80 lines) with project rules, quality gates,
+   and AI regression prevention. NEVER replace it with a single `@AGENTS.md` pointer.
+   If variable substitution fails, copy the template as-is and fill manually in STEP 3.
+   Verify after creation: `wc -l CLAUDE.md` must be >= 30 lines.
+2. `.claude/agents/` — from `templates/agents/`, minimum team only
+   Agent templates should include: role definition, key responsibilities,
+   "situations where this agent MUST speak up" (e.g., architect must flag
+   when protected files are changed), and inter-agent collaboration rules.
+   Reference: market-dashboard-v5 agents are 90+ lines each with career anchors
+   and project-specific context. Aim for at least 50 lines per agent.
+3. `.claude/hooks/` — copy from `templates/hooks/`
+4. `.claude/settings.json` — merge base `templates/settings.json` with type-specific deny-list:
+   `bash scripts/merge-settings.sh <project-type>` where project-type maps from service type:
+   - SaaS/content/internal-tool → `web-app`
+   - O2O/commerce → `payment`
+   - data → `cron-bot`
+   - trading (if detected in idea keywords) → `trading`
+   Write the merged output to `.claude/settings.json`.
+5. `.project/essence.md` — empty, filled in STEP 3
+6. `.project/PRD.md` — empty, filled in STEP 3
+7. `.project/decisions.md` — initialized with creation ADR
+8. `.project/backlog.md` — empty
+9. `.github/workflows/ci.yml` — from `templates/.github/workflows/ci.yml`
+10. `.github/workflows/label-pr.yml` — from `templates/.github/workflows/label-pr.yml`
+11. `.github/labeler.yml` — from `templates/.github/labeler.yml`
+12. `vercel.json` — from `templates/vercel.json` (preview 배포 비활성화, production만).
+    **Vercel 연결 후 필수 설정**: Dashboard > Settings > Git > "Production Branch" = `main`, Preview Deployments = OFF
+13. `.coderabbit.yaml` — from `templates/.coderabbit.yaml`
+14. `src/CONTRACT.md` — from `templates/documents/CONTRACT.md.tmpl`, replace `{{FEATURE_NAME}}` with service name
+15. `.project/handoff/` — empty directory for phase transition documents (template: `templates/documents/handoff.md.tmpl`)
+16. `scripts/create-pr.sh` — from `templates/scripts/create-pr.sh` (5-stage PR pipeline)
+17. `scripts/pre-deploy-consensus.sh` — from `templates/scripts/pre-deploy-consensus.sh` (6-gate deploy consensus)
+18. `scripts/review-summary.sh` — from `templates/scripts/review-summary.sh` (review summary auto-post)
+19. `scripts/run-architect.sh` — from `templates/scripts/run-architect.sh` (protected file review)
+20. `scripts/update-project-docs.sh` — from `templates/scripts/update-project-docs.sh` (auto doc update on PR)
+21. `.protected-files` — empty, filled after Phase 1 (files requiring architect review)
+22. `.githooks/pre-push` — from `templates/.githooks/pre-push` (stale review warning)
+23. `.github/workflows/token-health.yml` — from `templates/.github/workflows/token-health.yml` (weekly token check)
+24. `.project/quality-baseline.md` — empty, generated after Phase 2 (from `templates/documents/quality-baseline.md.tmpl`)
+25. **cron-bot/trading only** — additional files from `templates/cron-bot/scripts/`:
+    - `scripts/backtest.sh` — backtest runner (date range + config)
+    - `scripts/rollback.sh` — version rollback with audit logging
+    - `scripts/health-check.sh` — JSON health status reporter
+    - `templates/workflows/tuning-session.md` → `.project/tuning-protocol.md` (parameter tuning protocol)
+    - `.omc/experiments/` directory with README from `templates/experiments/README.md`
+26. `git init` + `git config core.hooksPath .githooks` + initial commit
+
+**Template variable reference**:
+- `{{SERVICE_NAME}}` — service name from analysis
+- `{{SERVICE_TYPE}}` — SaaS, O2O, commerce, etc.
+- `{{MISSION}}` — one-line description
+- `{{PROBLEM}}` — core problem
+- `{{TARGET}}` — target users
+- `{{DIFFERENTIATOR}}` — what makes it different
+- `{{TECH_STACK}}` — chosen tech stack (filled after kickoff)
+- `{{TEAM_TABLE}}` — markdown table rows for team roster, e.g. `| PM | pm | claude-sonnet-4-6 |`
+
+After completing STEP 2, proceed immediately to STEP 3.
+
+---
+
+## STEP 3 — Kickoff
+
+Ask CEO 3-5 questions using AskUserQuestion. Rules:
+- NO technical jargon
+- Present choices as A/B/C options
+- Topics: design feel, MVP scope, platform, revenue model
+- DO NOT ask about tech stack — team decides
+
+With answers:
+1. Fill `CLAUDE.md` Tech Stack section
+2. Write `.project/PRD.md` with 3-5 core features
+3. Write `.project/essence.md`:
+   - One-line definition
+   - Why this exists (the problem it solves)
+   - Wow factor (what makes users go "wow")
+   - Differentiator (what competitors don't do)
+   - Key metric (one number that matters)
+4. Record decisions in `.project/decisions.md`
+
+---
+
+## STEP 4 — Autonomous Build (Ralph Loop)
+
+Generate `.omc/prd.json` with stories in this order:
+
+```
+Phase 1 — MVP (mock data, local only)
+  MVP-001: Project init (packages, routing, layout)
+  MVP-002: Main screen with mock data
+  MVP-003: Core user flow #1
+  MVP-004: Core user flow #2 (if needed)
+  VALIDATE-001: MVP Gate (gate: true)
+
+  HANDOFF-MVP: Write MVP→Harden handoff document (see template)
+
+Phase 2 — Harden (real APIs, tests, security)
+  HARDEN-001: Replace mock with real data
+  HARDEN-002: Error handling + loading states
+  HARDEN-003: Tests
+  HARDEN-004: Security audit
+  HARDEN-005: Generate .protected-files list + run-architect.sh integration
+  HARDEN-006: Generate quality-baseline.md (ratchet rules — quality never goes down)
+  VALIDATE-002: Production Gate (gate: true)
+
+  HANDOFF-HARDEN: Write Harden→Ship handoff document (see template)
+
+Phase 3 — Ship
+  SHIP-001: gh repo create → bash scripts/setup-github.sh (branch protection + labels)
+  SHIP-002: Full 5-stage PR pipeline — build → code-reviewer artifact check →
+            Codex Gate → create-pr.sh (issue linking + bot polling) → review-summary.sh
+  SHIP-003: Deploy with pre-deploy-consensus.sh (6 gates must pass) + smoke test + retro
+  SHIP-004: Set up .githooks/pre-push + `git config core.hooksPath .githooks`
+  SHIP-005: Run update-project-docs.sh for final doc sync
+```
+
+Then start `/oh-my-claudecode:ralph`.
+
+**Gate stories** trigger parallel independent reviews.
+
+---
+
+## STEP 5 — Validate (Gate Execution)
+
+> **CRITICAL: Fresh Context Isolation**
+> Every gate reviewer MUST run with `isolation: "worktree"` (a separate copy of the project).
+> Reason: Anthropic's research proves that an agent evaluating its own work in the same
+> context always inflates quality ("Evaluator Leniency"). Fresh context = honest evaluation.
+> Reference: https://www.anthropic.com/engineering/harness-design-long-running-apps
+
+> **CRITICAL: Defect-Detection FIRST, Scoring SECOND (if at all)**
+> Step 1: Always start with adversarial defect-detection framing ("find every flaw").
+> Step 2: Only AFTER defects are listed, optionally score on 4 axes in a FRESH context.
+> WHY: Scoring without prior defect detection triggers "Rubric Gaming" — the AI optimizes
+> for high scores instead of finding problems. But scoring CAN work when the evaluator
+> has already committed to a defect list (Anthropic used scoring with tuned criteria
+> and a separated evaluator). The key: defects first, scores second, never same context.
+
+Four reviewers run in parallel, each in isolated worktree:
+
+- `architect` (opus, isolation: worktree): Structure adversarial review.
+  Prompt framing: "You are a hostile tech lead reviewing a junior's PR. Find every
+  structural problem that will block Phase 2. List every shortcut, every missing
+  abstraction, every coupling that will cause pain later. Be brutal."
+
+- `critic` (opus, isolation: worktree): Essence adversarial review.
+  Prompt framing: "You are a competitor analyzing this product. List every reason
+  a user would abandon this within 30 seconds. Find every place where the product
+  drifts from its core 'Why' in essence.md. What would you mock if you saw this
+  at a demo day?"
+
+- `code-reviewer` (opus, isolation: worktree): Code quality review.
+  Task-invoke the `code-reviewer` subagent. Its definition is vendored at
+  `.claude/agents/code-reviewer.md` (scaffolded from idea-factory's
+  `templates/agents/code-reviewer.md` at project creation). It runs a 2-stage
+  review: Stage 1 = spec compliance (does it match PRD?), Stage 2 = code quality
+  (security, SOLID, logic, performance). Issues are severity-rated (CRITICAL/HIGH/
+  MEDIUM/LOW). Only CRITICAL and HIGH block the gate.
+  This agent already enforces "never approve your own authoring output."
+
+- `qa-tester` (sonnet, isolation: worktree, tools: Playwright MCP): Functional review.
+  Prompt framing: "You are a frustrated beta tester who wants to break this app.
+  Open the running app in Playwright. Click every button, fill every form, try every
+  edge case. For each broken or confusing interaction, write: what you did, what you
+  expected, what actually happened. Screenshots are evidence."
+  **Playwright MCP required**: qa-tester MUST open the actual running app in a browser
+  and interact with it. Code-only review is NOT sufficient. If the app isn't running,
+  start it first. Test real clicks, real navigation, real data display.
+
+Cross-model review (mandatory when Codex CLI available):
+- If Codex CLI is installed, MUST run Codex Gate on the diff.
+  This is NOT optional — Gate 1 proved ROI (caught 2 bugs Claude missed).
+- If Codex CLI is not installed, log a warning in gate-results and skip.
+- Track results in `.project/codex-gate-log.md` for ROI evaluation.
+
+Gate evaluation (two-pass):
+- **Pass 1 — Defect Hunt** (mandatory): Each reviewer outputs a **defect list** first.
+  No scores allowed in this pass. Pure adversarial problem-finding.
+- **Pass 2 — Structured Score** (optional, fresh context): After defect lists are committed,
+  a separate agent MAY score on 4 axes: Functionality / Essence Alignment / Code Quality / UX.
+  Hard threshold: if any axis < 6/10, auto-fail. This pass is useful for tracking progress
+  across iterations but is NOT required for gate passage.
+- **Gate result logging** (mandatory): Save ALL reviewer outputs (defect lists + optional scores)
+  to `.project/gate-results/VALIDATE-{NNN}.md`. This enables post-mortem analysis and QA tuning.
+- Gate passes when: total critical defects = 0 across all four Pass 1 reviewers
+- If any critical defect found → add fix stories before the gate and retry
+- If all pass → ask CEO "Is this the right direction?" then proceed
+- After qa-tester completes, run `scripts/validate-qa-evidence.sh` on the output.
+  If zero Playwright evidence → qa-tester must re-run with actual browser interaction.
+
+Why two-pass works (for people reading this on GitHub):
+- Pass 1 alone: "Find every flaw as a hostile reviewer" → AI finds 5-15 real issues
+- Scoring alone: "Rate this 1-10" → AI gives 9/10 and moves on (Evaluator Leniency)
+- Two-pass: defects are already committed before scoring begins, so the scorer can't ignore them
+- Anthropic used scoring successfully — but with separated evaluators and tuned criteria
+- The failure mode is scoring WITHOUT prior defect detection in the SAME context
+
+### Essence Verification (every story completion)
+
+After each story, ask these adversarial questions (NOT scores):
+1. "If a user described this app in one sentence, would it match essence.md? If not, what's the gap?"
+2. "Would a competitor look at this feature and say 'that's clever'? Or 'that's generic'?"
+3. "If we removed this feature entirely, would the core value proposition survive?"
+
+If any answer reveals drift → flag in backlog with specific description of the drift.
+If drift is severe (feature contradicts the "Why") → escalate to CEO with pivot options.
+
+> Why no scores: Numeric drift scores (e.g., "drift = 5/10") trigger the same Evaluator Leniency
+> as scoring code quality. The AI will always report low drift to keep moving. Adversarial questions
+> force concrete, specific answers that reveal real problems.
+
+---
+
+## STEP 6 — Harden
+
+Harden stories execute after VALIDATE-001 passes:
+
+- HARDEN-001: Replace mock with real data
+- HARDEN-002: Error handling + loading states
+- HARDEN-003: Tests
+- HARDEN-004: Security audit
+- HARDEN-005: Generate .protected-files list + run-architect.sh integration
+- HARDEN-006: Generate quality-baseline.md (ratchet rules — quality never goes down)
+
+### Context Health Management (auto-compact + subagent isolation)
+- **60% Rule**: After every story, check context usage.
+  60% → `/compact Keep: essence, Phase, decisions, current story, bugs`
+  80% → checkpoint.md + warn CEO. 95% → STOP + new session.
+  NEVER let context reach 95% without compacting — degraded memory = garbage summary.
+- **Subagent Isolation**: Heavy work (tests, file search, code gen) → subagent.
+  Main session stays lightweight: direction, decisions, story management only.
+  Subagent returns summary, not raw output. This prevents context bloat.
+- **Checkpoint**: Every 10 stories or ~2 hours → `.project/checkpoint.md`
+- **Session Start**: CLAUDE.md includes 7-file read checklist for new sessions.
+- Reference: Anthropic "Context Reset with structured handoff" + /compact 60% rule
+  (https://www.mindstudio.ai/blog/claude-code-compact-command-context-management)
+
+### Ghost Bug Awareness
+- "Ghost Bugs" = code that looks perfect but fails in edge cases
+- Playwright testing (qa-tester) is the primary defense
+- After Phase 2 (Harden), add edge case scenarios to Playwright tests:
+  empty inputs, special characters, network timeouts, rapid double-clicks
+
+### Quality Ratchet (from market-dashboard-v5, proven across 13 phases)
+- After Phase 2 (Harden), generate `.project/quality-baseline.md`
+- Rule: quality metrics can only go UP, never DOWN
+- Covers: build status, test count, data accuracy, UI states, API fallback, deploy checklist
+- Every PR must not regress any baseline metric
+- If regression detected → block PR until fixed or CEO approves exception
+
+### Protected Files (architect review enforcement)
+- After Phase 1, identify core algorithm/business logic files → write to `.protected-files`
+- Any change to listed files triggers mandatory architect (opus) review
+- `run-architect.sh` generates review artifact; `create-pr.sh` verifies artifact exists and is fresh
+- Stale artifact (wrong commit hash) → PR blocked
+
+---
+
+## STEP 7 — Ship
+
+Ship stories execute after VALIDATE-002 passes:
+
+- SHIP-001: `gh repo create` → `bash scripts/setup-github.sh` (branch protection + labels)
+- SHIP-002: Full 5-stage PR pipeline — build → code-reviewer artifact check →
+            Codex Gate → `create-pr.sh` (issue linking + bot polling) → `review-summary.sh`
+- SHIP-003: Deploy with `pre-deploy-consensus.sh` (6 gates must pass) + smoke test + retro
+- SHIP-004: Set up `.githooks/pre-push` + `git config core.hooksPath .githooks`
+- SHIP-005: Run `update-project-docs.sh` for final doc sync


### PR DESCRIPTION
## 무엇을 바꿨나

`skills/start-company/SKILL.md`을 Skills 2.0 표준으로 분할 + frontmatter 확장.

- **SKILL.md**: 17KB → 3.1KB (진입점 + 원칙 + 실행 흐름 개요만)
- **phases.md** (신규, 16KB, 305줄): 7단계 상세 — ANALYZE/SCAFFOLD/KICKOFF/BUILD/VALIDATE/HARDEN/SHIP
- **agents.md** (신규, 8KB, 216줄): 에이전트 역할 정의 전체

Frontmatter 추가:
- `allowed-tools: [Read, Write, Edit, Bash, Task]`
- `disable-model-invocation: false`

## 왜 바꿨나

2025-12 Skills 2.0 표준 (Anthropic Engineering + anthropics/skills 공식 레포) 채택:
- **Progressive disclosure**: 스킬 비활성 시 metadata만 ~100토큰 스캔, 활성화 시에만 본문 로드
- **Codex / Cursor / Gemini CLI 호환**: 같은 포맷을 타 에이전트에서 재사용 가능
- **HARNESS-GUIDE.md 무수정**: 설계 문서는 별개 관심사로 분리

## 어떻게 검증했나

- [x] SKILL.md < 5KB 확인 (3135 bytes)
- [x] allowed-tools / disable-model-invocation frontmatter 추가
- [x] SKILL.md이 phases.md + agents.md를 명시적 참조
- [x] HARNESS-GUIDE.md mtime 2026-04-11 유지 (무수정)
- [x] 실행 흐름 의미 동등성 (모든 \`### STEP N\` 블록 원문 보존)

## 다운스트림 영향

- [x] 해당 없음 (이 레포 내부 변경만, skills/는 sync-manifest.json 추적 대상 아님)

## 체크리스트

- [x] 한국어 원자적 커밋 (\`feat:\`)
- [x] 관련 Issue: #22
- [x] 테스트 불필요 (파일 분할만, 실행 로직 동일)
- [x] 관련 문서 동기화 (ARCHITECTURE.md Q1 섹션에서 Skills 2.0 참조 가능)
- [x] .env / 시크릿 없음
- [ ] CodeRabbit 리뷰 통과 (자동 트리거)

Resolves #22