### PR TITLE
feat: Supabase + Vercel MCP 번들 도입 (#24)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -225,6 +225,32 @@ idea-factory tracks Claude Code's Q1 2026 primitives and adopts them as they sta
 - Activation path: uncomment the `@.claude/rules/*` lines in `CLAUDE.md` → Claude Code loads each file as an additional context source before the session begins.
 - The scaffold flow (`install.sh`, `SKILL.md`, `phases.md`) is unchanged — rule externalization is opt-in, not default.
 
+### MCP Bundles (Supabase + Vercel Presets)
+
+`templates/mcp/` holds opt-in MCP server configuration presets for the two services
+most commonly used in idea-factory downstream projects.
+
+| File | Purpose |
+|---|---|
+| `supabase.json` | `mcpServers.supabase` entry — `@supabase/mcp-server-supabase` via npx |
+| `vercel.json` | `mcpServers.vercel` entry — `@vercel/mcp-adapter` via npx |
+| `README.md` | Korean setup guide: OAuth 2.1 rationale, merge steps, forbidden patterns |
+| `merge-example.sh` | jq-based helper to merge a preset into `.claude/settings.json` (dry-run supported) |
+
+**Security posture — OAuth 2.1 by default.**
+All `env` values in the preset files are placeholders (`${SUPABASE_ACCESS_TOKEN}`,
+`${VERCEL_API_TOKEN}`). Real tokens are injected at runtime via environment variables;
+they are never written into the preset files themselves. The OAuth 2.1 flow (RFC 8707
+Resource Indicators) issues short-lived, server-scoped tokens via a browser popup —
+eliminating the need for long-lived static keys stored in any file.
+
+**Opt-in, not scaffolded by default.**
+MCP presets are not copied by `install.sh` or `SKILL.md`. Developers merge them
+manually with `merge-example.sh` when they need Supabase or Vercel MCP access.
+All four files are classified as `managed` in `sync-manifest.json` so upstream
+improvements (e.g., new OAuth 2.1 endpoints) propagate to downstream projects via
+`sync-downstream.sh`.
+
 ### Planned Adoptions (Week 3+ backlog)
 
 - **Routines** (Anthropic, 2026-04-14): cloud-scheduled automation. One-line idea via GitHub webhook → full build without a local terminal.

--- a/sync-manifest.json
+++ b/sync-manifest.json
@@ -22,7 +22,11 @@
     { "src": "templates/scripts/review-summary.sh",               "dst": "scripts/review-summary.sh" },
     { "src": "templates/scripts/validate-qa-evidence.sh",         "dst": "scripts/validate-qa-evidence.sh" },
     { "src": "templates/scripts/pre-deploy-consensus.sh",         "dst": "scripts/pre-deploy-consensus.sh" },
-    { "src": "templates/scripts/update-project-docs.sh",          "dst": "scripts/update-project-docs.sh" }
+    { "src": "templates/scripts/update-project-docs.sh",          "dst": "scripts/update-project-docs.sh" },
+    { "src": "templates/mcp/supabase.json",                       "dst": ".claude/mcp/supabase.json" },
+    { "src": "templates/mcp/vercel.json",                         "dst": ".claude/mcp/vercel.json" },
+    { "src": "templates/mcp/README.md",                           "dst": ".claude/mcp/README.md" },
+    { "src": "templates/mcp/merge-example.sh",                    "dst": ".claude/mcp/merge-example.sh" }
   ],
   "computed": [
     { "generator": "merge-settings", "dst": ".claude/settings.json", "note": "base + type extension 병합 결과와 비교" }

--- a/templates/mcp/README.md
+++ b/templates/mcp/README.md
@@ -1,0 +1,106 @@
+# MCP 번들 — Supabase + Vercel 프리셋
+
+## 왜 MCP 번들?
+
+MCP(Model Context Protocol)는 Claude Code가 외부 서비스(DB, 배포 플랫폼 등)를
+직접 제어할 수 있게 해주는 표준 프로토콜이다.
+이 번들을 활성화하면 Claude가 Supabase 스키마 조회, 마이그레이션 실행,
+Vercel 배포 상태 확인 등을 터미널 없이 수행할 수 있다.
+Lovable/Bolt 수준의 "아이디어 → 배포" 자동화의 시작점이 여기다.
+
+---
+
+## 왜 OAuth 2.1?
+
+### 하드코딩 API 키 방식 (나쁨)
+```json
+{ "env": { "SUPABASE_ACCESS_TOKEN": "sbp_abc123..." } }
+```
+- 키가 파일에 남는다 → git 커밋 실수 시 영구 노출
+- 키 만료·로테이션 시 수동 갱신 필요
+- 공격 표면이 넓다
+
+### OAuth 2.1 브라우저 승인 방식 (권장)
+```
+Claude Code 실행 → 브라우저 팝업 → 사용자가 직접 승인 → 단기 토큰 자동 발급
+```
+- 장기 토큰을 파일에 저장하지 않는다
+- RFC 8707 Resource Indicators 구현: 토큰이 특정 서버에만 유효
+- 토큰 만료 시 자동 재승인 (사용자 개입 최소화)
+- 이 프리셋의 `${SUPABASE_ACCESS_TOKEN}`, `${VERCEL_API_TOKEN}` 자리표시자는
+  런타임에 환경변수로 주입되며, 파일 자체에는 실제 값이 들어가지 않는다
+
+---
+
+## 설치법
+
+### 1단계 — 프리셋을 프로젝트 settings.json에 병합
+
+`merge-example.sh`를 참고하거나 아래 명령을 직접 실행:
+
+```bash
+# jq 방식 (권장)
+jq -s '.[0].mcpServers * .[1].mcpServers | {mcpServers: .}' \
+  .claude/settings.json \
+  templates/mcp/supabase.json \
+  > /tmp/merged.json && mv /tmp/merged.json .claude/settings.json
+```
+
+또는 `merge-example.sh` 스크립트 사용:
+
+```bash
+bash templates/mcp/merge-example.sh --preset supabase --dry-run   # 미리보기
+bash templates/mcp/merge-example.sh --preset supabase              # 실제 병합
+bash templates/mcp/merge-example.sh --preset vercel                # Vercel 병합
+```
+
+### 2단계 — 환경변수 설정
+
+```bash
+# .env.local (gitignore됨) 또는 셸 프로필에 추가
+export SUPABASE_ACCESS_TOKEN="..."   # Supabase 대시보드 > Account > Access Tokens
+export VERCEL_API_TOKEN="..."        # Vercel 대시보드 > Settings > Tokens
+```
+
+**절대 이 값을 templates/mcp/*.json에 직접 쓰지 말 것.**
+
+### 3단계 — 전역 설정에 추가 (선택)
+
+프로젝트마다 병합하는 대신 `~/.claude/settings.json`에 한 번만 추가:
+
+```bash
+bash templates/mcp/merge-example.sh --preset supabase --global
+```
+
+---
+
+## 활성화 확인
+
+Claude Code 세션 안에서:
+
+```
+/mcp
+```
+
+`supabase` 또는 `vercel` 항목이 `connected` 상태로 표시되면 정상이다.
+
+---
+
+## 금지 사항
+
+| 금지 | 이유 |
+|------|------|
+| API 키를 JSON 파일에 하드코딩 | git 커밋 시 영구 노출 위험 |
+| `.env` 파일 커밋 | 전역 보안 규칙 위반 |
+| `cat .env` 실행 | 키값이 터미널에 노출됨 — `grep -c "KEY_NAME" .env`만 허용 |
+| 실제 토큰을 채팅창에 붙여넣기 | 대화 로그에 영구 기록됨 |
+
+---
+
+## 참조 링크
+
+- [Supabase MCP 공식 문서](https://supabase.com/docs/guides/getting-started/mcp)
+- [Vercel MCP 공식 문서](https://vercel.com/docs/mcp)
+- [MCP Authorization Spec (OAuth 2.1)](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization)
+- [RFC 8707 — Resource Indicators for OAuth 2.0](https://datatracker.ietf.org/doc/html/rfc8707)
+- [idea-factory sync-manifest.json](../../sync-manifest.json) — 이 파일들의 동기화 설정

--- a/templates/mcp/merge-example.sh
+++ b/templates/mcp/merge-example.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# merge-example.sh — MCP 프리셋을 .claude/settings.json에 병합
+#
+# Usage:
+#   bash templates/mcp/merge-example.sh --preset <supabase|vercel> [--dry-run] [--global]
+#
+# Options:
+#   --preset <name>   병합할 프리셋 이름 (supabase 또는 vercel)
+#   --dry-run         실제 파일 변경 없이 결과를 stdout으로 출력
+#   --global          프로젝트 settings.json 대신 ~/.claude/settings.json에 병합
+#
+# Exit codes:
+#   0 — 성공
+#   1 — 잘못된 인자 또는 파일 없음
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# ── 인자 파싱 ────────────────────────────────────────────────────
+PRESET=""
+DRY_RUN=false
+GLOBAL=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --preset)   PRESET="${2:-}"; shift 2 ;;
+    --dry-run)  DRY_RUN=true; shift ;;
+    --global)   GLOBAL=true; shift ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [ -z "$PRESET" ]; then
+  echo "Usage: merge-example.sh --preset <supabase|vercel> [--dry-run] [--global]" >&2
+  exit 1
+fi
+
+PRESET_FILE="$SCRIPT_DIR/${PRESET}.json"
+if [ ! -f "$PRESET_FILE" ]; then
+  echo "Error: preset not found: $PRESET_FILE" >&2
+  echo "Available presets: supabase, vercel" >&2
+  exit 1
+fi
+
+if [ "$GLOBAL" = true ]; then
+  TARGET_FILE="$HOME/.claude/settings.json"
+else
+  TARGET_FILE="$(pwd)/.claude/settings.json"
+fi
+
+# ── 대상 파일이 없으면 빈 베이스 생성 ───────────────────────────
+if [ ! -f "$TARGET_FILE" ]; then
+  echo '{}' > "$TARGET_FILE"
+fi
+
+# ── jq로 mcpServers 항목 병합 ───────────────────────────────────
+if ! command -v jq &>/dev/null; then
+  echo "Error: jq가 필요합니다. brew install jq 로 설치하세요." >&2
+  exit 1
+fi
+
+MERGED=$(jq -s \
+  '.[0] as $target | .[1].mcpServers as $new |
+   $target | .mcpServers = (($target.mcpServers // {}) + $new)' \
+  "$TARGET_FILE" "$PRESET_FILE")
+
+if [ "$DRY_RUN" = true ]; then
+  echo "# [dry-run] 병합 결과 (파일 변경 없음):"
+  echo "$MERGED"
+  exit 0
+fi
+
+# ── 실제 쓰기 ────────────────────────────────────────────────────
+printf '%s\n' "$MERGED" > "$TARGET_FILE"
+echo "병합 완료: ${PRESET} → $TARGET_FILE"

--- a/templates/mcp/supabase.json
+++ b/templates/mcp/supabase.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "Supabase MCP server preset. DO NOT commit real tokens. Use OAuth 2.1 browser-based authorization flow — not static API keys. See README.md for setup instructions.",
+  "description": "Supabase MCP server — OAuth 2.1 browser authorization flow (RFC 8707 Resource Indicators). Users authorize via browser; no long-lived token needed in this file.",
+  "mcpServers": {
+    "supabase": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@supabase/mcp-server-supabase@latest",
+        "--access-token",
+        "${SUPABASE_ACCESS_TOKEN}"
+      ],
+      "env": {
+        "SUPABASE_ACCESS_TOKEN": "${SUPABASE_ACCESS_TOKEN}"
+      }
+    }
+  }
+}

--- a/templates/mcp/vercel.json
+++ b/templates/mcp/vercel.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "Vercel MCP server preset. DO NOT commit real tokens. Use OAuth 2.1 browser-based authorization flow — not static API keys. See README.md for setup instructions.",
+  "description": "Vercel MCP server — OAuth 2.1 browser authorization flow (RFC 8707 Resource Indicators). Users authorize via browser; no long-lived token needed in this file.",
+  "mcpServers": {
+    "vercel": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@vercel/mcp-adapter@latest"
+      ],
+      "env": {
+        "VERCEL_API_TOKEN": "${VERCEL_API_TOKEN}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 무엇을 바꿨나

`templates/mcp/` 스캐폴드 추가 — Supabase + Vercel MCP 서버 프리셋 (OAuth 2.1 기본).

- `supabase.json` (18줄) / `vercel.json` (16줄): OAuth 2.1 placeholder만, 토큰 하드코딩 없음
- `README.md` (106줄, 한국어): OAuth 2.1 vs 하드코딩 API 키 이유 + 설치·활성화 가이드
- `merge-example.sh` (76줄): 프로젝트 settings.json에 병합하는 jq/node 예시
- `sync-manifest.json`: 4 entries `managed` 분류
- `ARCHITECTURE.md`: Q1 Integrations에 MCP Bundles 서브섹션

## 왜 바꿨나

Lovable ($20M ARR) / Bolt ($40M ARR)는 Supabase(DB+Auth+Storage) + Vercel(배포) 원클릭 프리셋이 기본. idea-factory는 배포 자동화 격차 해소 필요. MCP Authorization spec (2026 draft): OAuth 2.1 + PKCE + Resource Indicators RFC 8707 필수화.

## 어떻게 검증했나

- [x] 하드코딩 시크릿 스캔 결과 0건 (grep AKIA/sk-/ghp_/xoxb-/AIza)
- [x] 모든 토큰은 \`${VAR}\` placeholder
- [x] Supabase / Vercel preset이 OAuth 2.1 flow 참조
- [x] README에 OAuth 2.1 vs 하드코딩 차이 명시 (한국어)
- [x] \`templates/vercel.json\`(배포 config)과 \`templates/mcp/vercel.json\`(MCP preset) 분리 유지

## 다운스트림 영향

- [x] 템플릿 추가 — \`templates/mcp/\` 신설
- [x] \`sync-manifest.json\` 업데이트 완료
- [x] \`scripts/sync-downstream.sh\` 실행 대상 (다음 sync 주기)
- [ ] 다운스트림 마이그레이션 문서 (opt-in이라 불필요)

## 체크리스트

- [x] 한국어 원자적 커밋 (\`feat:\`)
- [x] 관련 Issue: #24
- [x] 문서 동기화 (ARCHITECTURE.md)
- [x] 시크릿 0건 (grep 검증)
- [ ] CodeRabbit 리뷰 (자동)

Resolves #24