### PR TITLE
feat: Claude Code Routines 통합 + 디코 웹훅 가이드 (#29)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -251,9 +251,36 @@ All four files are classified as `managed` in `sync-manifest.json` so upstream
 improvements (e.g., new OAuth 2.1 endpoints) propagate to downstream projects via
 `sync-downstream.sh`.
 
+### Routines (Cloud Automation)
+
+Shipped 2026-04-14 as research preview. Scaffold merged on `feature/#29-routines-integration`.
+
+**What it enables**: A CEO posts a one-line idea to Discord → a GitHub Issue is created →
+a Claude Code Routine fires on Anthropic-managed cloud infrastructure → `/start-company`
+runs without any local terminal → PR created → Discord notification sent back.
+
+**Status**: scaffold shipped — reference template and guides in `templates/routines/`.
+
+**When to use**:
+- Async idea intake: CEO submits ideas anytime; Claude processes them on the next trigger
+- Unattended overnight builds: schedule a nightly routine to advance MVP phases
+- CI/CD hooks: fire a routine from deploy pipelines for smoke tests or alert triage
+
+**Tier quotas** (daily run limit): Pro 5 / Max 15 / Team+Enterprise 25.
+Extra runs available via Settings > Billing (metered overage).
+
+**Files**:
+- `templates/routines/idea-to-mvp.yaml` — annotated routine configuration reference
+- `templates/routines/README.md` — Korean quick-start guide
+- `docs/routines-integration.md` — end-to-end integration guide (English + Korean)
+
+**Constraints**:
+- Research preview: schema, API surface, and limits subject to change
+- GitHub Issues event not yet a native trigger; bridge via GitHub Actions + API trigger
+- Each run is a fresh session; inter-run state must be passed via committed files
+
 ### Planned Adoptions (Week 3+ backlog)
 
-- **Routines** (Anthropic, 2026-04-14): cloud-scheduled automation. One-line idea via GitHub webhook → full build without a local terminal.
 - **Agent Teams + Worktree**: parallel workers across isolated worktrees, coordinated by a team-leader session. Requires `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`.
 - **Plugin Marketplace**: package idea-factory as an official plugin (`anthropics/claude-plugins-official`) for one-command install.
 

--- a/docs/routines-integration.md
+++ b/docs/routines-integration.md
@@ -1,0 +1,318 @@
+# Claude Code Routines — End-to-End Integration Guide
+# Claude Code Routines — 통합 운영 가이드
+
+> **Status / 상태**: Research preview (launched 2026-04-14). Schema and limits subject to change.
+> **Reference**: https://code.claude.com/docs/en/routines
+
+---
+
+## Table of Contents / 목차
+
+1. [What This Guide Covers](#what-this-guide-covers)
+2. [Actor Diagram — idea-to-mvp flow](#actor-diagram)
+3. [Setup: Prerequisites](#setup-prerequisites)
+4. [Setup: Discord Webhook](#setup-discord-webhook)
+5. [Setup: GitHub Configuration](#setup-github-configuration)
+6. [Setup: Claude Account & Routine Creation](#setup-claude-account--routine-creation)
+7. [Cost Model](#cost-model)
+8. [Failure Modes & Retry Semantics](#failure-modes--retry-semantics)
+9. [Security Checklist](#security-checklist)
+10. [Korean Summary / 한국어 요약](#korean-summary)
+
+---
+
+## What This Guide Covers
+
+This guide walks through the complete flow for the `idea-to-mvp` routine:
+a CEO posts a one-line idea to a Discord channel, which triggers a GitHub Issue,
+which fires a Claude Code Routine, which runs `/start-company`, creates a PR,
+and posts the result back to Discord — all without opening a terminal.
+
+The same pattern generalises to any event-driven automation on top of idea-factory.
+
+---
+
+## Actor Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                         idea-to-mvp flow                            │
+└─────────────────────────────────────────────────────────────────────┘
+
+  CEO (non-technical)
+       │
+       │  1. Types one-line idea into #아이디어 Discord channel
+       ▼
+  Discord Bot / GitHub Actions bridge
+       │
+       │  2. Creates GitHub Issue with label "idea"
+       │     title: "고양이 SNS"
+       ▼
+  GitHub (repository event)
+       │
+       │  3. Issue-opened event fires
+       │     → GitHub Actions workflow calls Routine API trigger
+       ▼
+  Claude Code Routine (Anthropic cloud)
+       │
+       │  4. New cloud session starts (no local machine needed)
+       │     Prompt: "Read issue #N, run /start-company <idea>"
+       │
+       ├─ 4a. Clones repository
+       ├─ 4b. Runs /start-company "고양이 SNS"
+       │       └─ ANALYZE → SCAFFOLD → KICKOFF → BUILD MVP
+       ├─ 4c. PR created on claude/idea-N branch
+       └─ 4d. POST to DISCORD_WEBHOOK_URL with PR link
+       │
+       ▼
+  Discord #아이디어 channel
+       │
+       │  5. Bot posts: "MVP scaffold ready for #42: 고양이 SNS — PR: <URL>"
+       ▼
+  CEO reviews PR
+       │
+       │  6. Approves or provides feedback in PR comments
+       ▼
+  (Subsequent runs handle VALIDATE → HARDEN → SHIP phases)
+```
+
+> **Note on GitHub Issues trigger**: As of the research preview, Routines support
+> `pull_request` and `release` GitHub events natively. The Issues event is not yet
+> available as a direct trigger. The recommended bridge is a lightweight GitHub Actions
+> workflow (`.github/workflows/idea-routine-bridge.yml`) that fires on `issues.opened`
+> with label `idea` and POSTs to the Routine's API trigger endpoint.
+> See the workflow snippet in the Setup section below.
+
+---
+
+## Setup: Prerequisites
+
+Before creating the routine, ensure the following are in place:
+
+| Requirement | Where to configure |
+|---|---|
+| Claude Code on the web enabled | claude.ai > Settings > Claude Code |
+| GitHub account connected to Claude | `/web-setup` in Claude CLI |
+| Claude GitHub App installed on target repo | Prompted during routine creation |
+| Discord server with a webhook-enabled channel | Discord channel settings |
+| Claude plan: Pro / Max / Team / Enterprise | claude.ai > Settings > Billing |
+
+---
+
+## Setup: Discord Webhook
+
+**Never hardcode the webhook URL in any file. Use environment variables only.**
+
+### Step 1 — Create the webhook in Discord
+
+1. Open Discord → target channel → **Edit Channel** → **Integrations** → **Webhooks**
+2. Click **New Webhook**, give it a name (e.g. `idea-factory-bot`)
+3. Click **Copy Webhook URL** — format: `https://discord.com/api/webhooks/<ID>/<TOKEN>`
+
+### Step 2 — Store in Claude Cloud Environment
+
+1. Go to `https://claude.ai/code/routines` → **Settings > Environments**
+2. Select (or create) the environment for this routine
+3. Under **Environment Variables**, add:
+   - Key: `DISCORD_WEBHOOK_URL` / Value: the copied URL
+   - Key: `GITHUB_TOKEN` / Value: a GitHub PAT with `repo` scope (or GitHub App token)
+4. Save the environment
+
+The routine prompt references `${DISCORD_WEBHOOK_URL}` — the value is injected at
+runtime and never written to any file or log.
+
+### Step 3 — Test the webhook manually
+
+```bash
+curl -X POST "${DISCORD_WEBHOOK_URL}" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "idea-factory webhook test"}'
+```
+
+Expected: a message appears in the Discord channel.
+
+---
+
+## Setup: GitHub Configuration
+
+### GitHub Actions bridge workflow
+
+Since the Issues event is not yet a native Routine trigger, use this workflow
+to bridge GitHub Issues → Routine API endpoint.
+
+Save as `.github/workflows/idea-routine-bridge.yml` in the target repository:
+
+```yaml
+name: idea-routine-bridge
+
+on:
+  issues:
+    types: [opened, labeled]
+
+jobs:
+  fire-routine:
+    if: contains(github.event.issue.labels.*.name, 'idea')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger idea-to-mvp routine
+        run: |
+          curl -X POST \
+            "https://api.anthropic.com/v1/claude_code/routines/${{ secrets.IDEA_ROUTINE_ID }}/fire" \
+            -H "Authorization: Bearer ${{ secrets.IDEA_ROUTINE_API_TOKEN }}" \
+            -H "anthropic-beta: experimental-cc-routine-2026-04-01" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "Content-Type: application/json" \
+            -d "{\"text\": \"Issue #${{ github.event.issue.number }}: ${{ github.event.issue.title }}\"}"
+```
+
+Add two repository secrets in GitHub (Settings > Secrets and variables > Actions):
+- `IDEA_ROUTINE_ID` — the routine ID from the URL at `claude.ai/code/routines/<ID>`
+- `IDEA_ROUTINE_API_TOKEN` — generated in the Routine's API trigger modal (shown once)
+
+### Branch protection
+
+Routines push to `claude/`-prefixed branches by default. Ensure branch protection
+rules on `main` do not block PR creation from `claude/*` branches.
+
+---
+
+## Setup: Claude Account & Routine Creation
+
+### Option A — Web UI
+
+1. Visit `https://claude.ai/code/routines` → **New routine**
+2. **Name**: `idea-to-mvp`
+3. **Prompt**: paste the prompt from `templates/routines/idea-to-mvp.yaml`
+4. **Repository**: select the target repo; leave unrestricted pushes disabled
+5. **Environment**: select the environment with `DISCORD_WEBHOOK_URL` configured
+6. **Trigger**: choose **API** (the GitHub Actions workflow will call it)
+7. After saving, open the routine → API trigger modal → **Generate token**
+8. Copy the token immediately and store it as `IDEA_ROUTINE_API_TOKEN` in GitHub secrets
+
+### Option B — CLI
+
+```
+/schedule idea-to-mvp: when triggered via API, read the issue number and idea
+from the request text, run /start-company, open a PR, and POST the result to
+the DISCORD_WEBHOOK_URL environment variable.
+```
+
+After `/schedule` creates the routine, add the API trigger and environment
+variables from the web UI.
+
+---
+
+## Cost Model
+
+### Which tier supports a burst of ideas?
+
+Each routine run consumes one slot from the daily routine allowance AND draws
+from the standard subscription usage (token cost of the Claude session).
+
+| Scenario | Recommended tier | Reasoning |
+|---|---|---|
+| 1–5 ideas/day | **Pro** (5/day) | Exactly fits the limit; no overage |
+| 6–15 ideas/day | **Max** (15/day) | Comfortable headroom |
+| Team use, 15–25 ideas/day | **Team** (25/day) | Shared account; each member's runs count separately |
+| Burst events (hackathon, launch day) | Any tier + **extra usage** | Enable in Settings > Billing; overage is metered |
+
+### Token cost per run
+
+A full `/start-company` run through ANALYZE + SCAFFOLD + KICKOFF + MVP phases
+typically uses 200k–600k tokens (Sonnet 4.6 default, Opus for gate reviews).
+At standard pricing this is $0.30–$1.50 per idea at list rates.
+Enable extra usage for predictable cost; monitor at `claude.ai/settings/usage`.
+
+### GitHub Actions cost
+
+The bridge workflow runs on `ubuntu-latest` and completes in under 10 seconds
+(single curl call). At GitHub's free tier (2,000 min/month on public repos,
+2,000 min on private), this adds negligible cost.
+
+---
+
+## Failure Modes & Retry Semantics
+
+### Routine-level failures
+
+| Failure | Cause | Resolution |
+|---|---|---|
+| Run rejected at trigger time | Daily cap reached | Enable extra usage, or wait for midnight reset |
+| GitHub App not installed | Webhook delivery fails silently | Install Claude GitHub App via routine edit form |
+| API token expired / revoked | 401 from `/fire` endpoint | Regenerate token in routine's API trigger modal |
+| Routine times out mid-session | Very long `/start-company` run | Add explicit checkpoints in prompt; split into phases |
+
+### Retry semantics
+
+Routines do **not** automatically retry a failed run. Each trigger event starts
+exactly one session. If a run fails:
+
+1. Check the session log at `claude.ai/code/routines` → click the failed run
+2. Identify the failure point (network error, token cost cap, tool failure)
+3. Click **Run now** on the routine detail page to manually re-trigger
+4. Or re-open / re-label the GitHub Issue to re-fire the GitHub Actions bridge
+
+### `/start-company` circuit breaker
+
+If the inner `/start-company` session hits the fix-loop circuit breaker
+(same story fails 3 times), it escalates to the CEO. In a Routine context this
+means the session will write a `decisions.md` entry and stop. Check the session
+log for the escalation message and intervene manually.
+
+### Discord webhook failures
+
+If `DISCORD_WEBHOOK_URL` is missing or the POST fails, the Routine session will
+log the error but the PR is still created. The routine prompt should treat the
+Discord notification as best-effort, not a blocking requirement.
+
+---
+
+## Security Checklist
+
+- [ ] `DISCORD_WEBHOOK_URL` stored only in Claude Cloud Environment, not in any file
+- [ ] `GITHUB_TOKEN` stored only in Claude Cloud Environment; minimum scope (`repo`)
+- [ ] `IDEA_ROUTINE_API_TOKEN` stored only in GitHub Actions secret; never in code
+- [ ] `IDEA_ROUTINE_ID` is not sensitive (it is a public identifier) but keep it in secrets for hygiene
+- [ ] Routine scope limited: only the target repository is attached
+- [ ] Connectors list trimmed: only `github` connector enabled for this routine
+- [ ] Branch push restricted to `claude/*` prefix (default; do not disable)
+- [ ] API token rotated if ever exposed: **Regenerate** in routine's API trigger modal
+- [ ] Claude GitHub App granted minimum repository access (single repo, not all repos)
+- [ ] OAuth 2.1 flow: Claude's GitHub identity uses short-lived tokens per session
+
+---
+
+## Korean Summary
+
+### 전체 흐름 요약
+
+1. **대표**: Discord `#아이디어` 채널에 한 줄 아이디어 입력
+2. **Discord → GitHub 브릿지**: GitHub Issue 자동 생성 (라벨: `idea`)
+3. **GitHub Actions**: Issue 오픈 이벤트 감지 → Routine API trigger 호출
+4. **Claude Code Routine** (Anthropic 클라우드):
+   - 새 세션 시작 — 로컬 머신 불필요
+   - `/start-company "<아이디어>"` 실행
+   - ANALYZE → SCAFFOLD → KICKOFF → MVP 단계 자동 진행
+   - PR 생성 → Discord webhook POST
+5. **대표**: Discord에서 PR 링크 수신 → 검토·승인
+
+### 설정 체크리스트
+
+- [ ] Claude Code on the web 활성화 (`claude.ai > Settings > Claude Code`)
+- [ ] GitHub 연결 (`/web-setup` in CLI)
+- [ ] Discord Incoming Webhook URL 발급 후 Claude Cloud Environment에 등록
+- [ ] GitHub Actions 브릿지 워크플로우 배포 (`.github/workflows/idea-routine-bridge.yml`)
+- [ ] Routine 생성 후 API 토큰 → GitHub Actions secret 등록
+- [ ] 테스트: Issue 등록 → Discord 알림 확인
+
+### 요금 가이드
+
+- 하루 5건 이내: Pro 충분
+- 하루 6–15건: Max 권장
+- 팀 운영 또는 폭발적 아이디어 기간: Team + extra usage 활성화
+
+### 관련 파일
+
+- `templates/routines/idea-to-mvp.yaml` — 루틴 설정 레퍼런스
+- `templates/routines/README.md` — 한국어 빠른 시작 가이드
+- `ARCHITECTURE.md` — Routines 아키텍처 섹션

--- a/sync-manifest.json
+++ b/sync-manifest.json
@@ -26,7 +26,9 @@
     { "src": "templates/mcp/supabase.json",                       "dst": ".claude/mcp/supabase.json" },
     { "src": "templates/mcp/vercel.json",                         "dst": ".claude/mcp/vercel.json" },
     { "src": "templates/mcp/README.md",                           "dst": ".claude/mcp/README.md" },
-    { "src": "templates/mcp/merge-example.sh",                    "dst": ".claude/mcp/merge-example.sh" }
+    { "src": "templates/mcp/merge-example.sh",                    "dst": ".claude/mcp/merge-example.sh" },
+    { "src": "templates/routines/idea-to-mvp.yaml",               "dst": ".claude/routines/idea-to-mvp.yaml" },
+    { "src": "templates/routines/README.md",                      "dst": ".claude/routines/README.md" }
   ],
   "computed": [
     { "generator": "merge-settings", "dst": ".claude/settings.json", "note": "base + type extension 병합 결과와 비교" }

--- a/templates/routines/README.md
+++ b/templates/routines/README.md
@@ -1,0 +1,153 @@
+# Claude Code Routines — 아이디어 자동화 가이드
+
+> **상태**: 2026-04-14 리서치 프리뷰 출시. 스키마·한도·API는 변경될 수 있음.
+
+---
+
+## Routines란 무엇인가
+
+Claude Code Routines는 Claude Code 세션을 클라우드에서 자동으로 실행하는 기능이다.
+로컬 터미널을 열지 않아도, 맥북이 꺼져 있어도 작업이 돌아간다.
+
+**핵심 개념**: 루틴 = 프롬프트 + 레포지토리 + 환경(시크릿·툴) + 트리거.
+한 번 설정하면 조건이 맞을 때마다 Claude가 알아서 실행한다.
+
+**2026-04-14 의미**: 지금까지 `/start-company`를 실행하려면 터미널을 켜야 했다.
+Routines 출시 이후로는 "아이디어를 GitHub Issue에 올리면 → Claude가 알아서 MVP 스캐폴딩까지"
+하는 흐름이 가능해졌다. 대표가 코드 한 줄 없이 아이디어를 접수하고 자동으로 PR을 받는 세계다.
+
+---
+
+## 트리거 유형 3가지
+
+| 트리거 | 설명 | idea-factory 활용 예 |
+|---|---|---|
+| **Schedule** | 시간 기반 반복 실행 (매시·매일·매주 등) | 매주 월요일 아침 백로그 정리 |
+| **GitHub Event** | PR 생성·릴리즈 등 GitHub 이벤트 반응 | Issue 등록 시 `/start-company` 자동 실행 |
+| **API** | HTTP POST로 온디맨드 실행 | 외부 알림 시스템이 루틴을 직접 호출 |
+
+단일 루틴에 여러 트리거를 동시에 붙일 수 있다.
+예: GitHub Issue 트리거 + API 트리거를 같은 루틴에.
+
+---
+
+## 요금제별 일일 한도 (2026-04-14 기준)
+
+| 요금제 | 일 실행 한도 |
+|---|---|
+| **Pro** | 5회/일 |
+| **Max** | 15회/일 |
+| **Team / Enterprise** | 25회/일 |
+
+한도 초과 시 `Settings > Billing`에서 추가 사용(extra usage)을 활성화하면
+초과분은 종량제로 계속 실행된다. 비활성화 상태이면 한도 초과 루틴은 거부된다.
+
+**아이디어 팩토리 운영 기준**: 아이디어가 하루 5개 이하이면 Pro로 충분하다.
+스타트업 초기 아이디어 폭발 기간이라면 Max 이상을 권장한다.
+
+현재 소비량 확인: `https://claude.ai/settings/usage`
+
+---
+
+## idea-to-mvp 루틴 — 사용 예시
+
+### 흐름 요약
+
+```
+대표가 GitHub Issue 등록
+  (제목: "고양이 SNS", 라벨: idea)
+        │
+        ▼
+Routine 자동 트리거
+        │
+        ▼
+Claude가 /start-company "고양이 SNS" 실행
+        │
+        ▼
+MVP 스캐폴딩 완료 → PR 생성
+        │
+        ▼
+Discord 채널에 알림 + Issue에 PR 링크 코멘트
+```
+
+### 설정 단계
+
+1. `claude.ai/code/routines`에서 **New routine** 클릭
+2. 이 폴더의 `idea-to-mvp.yaml` 값을 참고해 폼 입력
+3. 환경 변수 설정 (아래 섹션 참고)
+4. GitHub 트리거 선택 → 레포 연결 → 라벨 필터 `idea` 설정
+5. **Create** 클릭 → 루틴 저장
+
+CLI로 생성하려면 Claude Code 세션에서:
+```
+/schedule idea-to-mvp: GitHub Issue(라벨 idea) 등록 시 /start-company 실행 후 Discord 알림
+```
+
+---
+
+## 디스코드 Webhook 준비 방법
+
+**절대 규칙: Webhook URL을 코드나 YAML에 하드코딩하지 않는다.**
+
+### Discord에서 Webhook URL 발급
+
+1. Discord 서버 → 채널 설정 → **연동** → **웹후크**
+2. **새 웹후크** → 이름 지정 → **웹후크 URL 복사**
+3. URL 형식: `https://discord.com/api/webhooks/<ID>/<TOKEN>`
+
+### Claude Cloud 환경에 등록
+
+1. `claude.ai/code/routines` → **Settings > Environments**
+2. 루틴에 연결된 환경 선택 (또는 새 환경 생성)
+3. Environment Variables에 추가:
+   - `DISCORD_WEBHOOK_URL` = 복사한 Webhook URL
+   - `GITHUB_TOKEN` = repo 권한이 있는 Personal Access Token 또는 GitHub App 토큰
+4. **저장** — 이제 루틴 실행 시 `${DISCORD_WEBHOOK_URL}`로 값을 읽는다
+
+루틴 프롬프트 안에서 Claude는 이 환경변수를 자동으로 사용할 수 있다.
+
+---
+
+## 한계 및 주의사항
+
+### 실험적 기능 (Research Preview)
+
+- 스키마·API·한도는 예고 없이 변경될 수 있다.
+- GitHub 트리거는 현재 `pull_request`와 `release` 이벤트만 지원.
+  Issues 이벤트 구독은 아직 미지원 → API 트리거로 우회 (YAML 주석 참고).
+- GitHub webhook 이벤트에는 시간당 루틴당 별도 상한이 있다.
+  아이디어가 짧은 시간에 대량 접수되면 일부가 드롭될 수 있다.
+
+### 컨텍스트 제약
+
+루틴은 매 실행마다 새 세션으로 시작된다. 이전 실행의 컨텍스트를 기억하지 않는다.
+장기 실행 루틴(예: `/start-company` 전체 7단계)은 1M 컨텍스트 윈도우 내에서
+동작하지만, 세션 간 상태는 파일(handoff 문서, `.project/`)로 넘겨야 한다.
+
+### 권한 범위 최소화
+
+루틴은 승인 프롬프트 없이 완전 자율 실행된다.
+레포지토리 접근 범위, 환경변수, 커넥터를 루틴이 실제로 필요한 것만으로 제한할 것.
+기본적으로 Claude는 `claude/`로 시작하는 브랜치에만 push한다.
+무제한 브랜치 push는 명시적으로 활성화해야 한다.
+
+---
+
+## 보안 규칙
+
+이 프로젝트의 시크릿 정책을 루틴에도 동일하게 적용한다:
+
+- **DISCORD_WEBHOOK_URL**, **GITHUB_TOKEN** 등 모든 시크릿은 `${VAR_NAME}` 플레이스홀더만 사용
+- YAML 파일, 프롬프트 텍스트, 커밋 메시지에 실제 토큰값 절대 포함 금지
+- Claude의 인증은 OAuth 2.1 기반 — 단기 토큰이 세션마다 발급됨
+- API 트리거 토큰은 생성 직후 1회만 표시됨 → 즉시 안전한 저장소에 보관
+- 토큰 노출이 의심되면 루틴 편집 > API 트리거 모달 > **Regenerate** 즉시 실행
+
+---
+
+## 참고 링크
+
+- 루틴 관리 UI: `https://claude.ai/code/routines`
+- 공식 문서: `https://code.claude.com/docs/en/routines`
+- 출시 포스트: `https://claude.com/blog/introducing-routines-in-claude-code`
+- 통합 가이드 (영문+한국어): `../../docs/routines-integration.md`

--- a/templates/routines/idea-to-mvp.yaml
+++ b/templates/routines/idea-to-mvp.yaml
@@ -1,0 +1,119 @@
+# idea-to-mvp — Claude Code Routine definition
+#
+# NOTE: As of 2026-04-14, Claude Code Routines do not use a file-based YAML
+# schema. Routines are created and managed via:
+#   - Web UI:  https://claude.ai/code/routines
+#   - CLI:     /schedule (or /schedule daily ... )
+#   - Desktop: New task > New remote task
+#
+# This file documents the intended configuration as a reference template.
+# Copy the values below into the web creation form or use `/schedule` in CLI.
+# Adjust field names if Anthropic ships a file-based schema in a future release.
+#
+# Reference: https://code.claude.com/docs/en/routines
+# Beta header (API trigger): anthropic-beta: experimental-cc-routine-2026-04-01
+
+routine:
+  name: idea-to-mvp
+  description: >
+    One-line idea arrives via GitHub Issue (label: idea) →
+    runs /start-company → opens a PR → posts result link to Discord webhook.
+
+  # -----------------------------------------------------------------
+  # Prompt — the most important field; must be self-contained.
+  # Routines run autonomously with no approval prompts.
+  # -----------------------------------------------------------------
+  prompt: |
+    A new GitHub Issue has been opened with the label "idea".
+    The issue body contains a one-line business idea.
+
+    Steps:
+    1. Read the issue body and extract the one-line idea text.
+    2. Run `/start-company "<idea>"` inside a new subdirectory named
+       after the issue number (e.g. idea-<ISSUE_NUMBER>/).
+       Create the subdirectory first if it does not exist.
+    3. Wait for /start-company to complete and locate the resulting PR URL.
+    4. Send a POST request to the Discord webhook URL stored in the
+       environment variable DISCORD_WEBHOOK_URL with a JSON body:
+         {
+           "content": "New MVP scaffold ready for idea #<ISSUE_NUMBER>: <idea>\nPR: <PR_URL>"
+         }
+    5. Comment on the original GitHub Issue with the PR URL so the
+       requester can track progress.
+
+    Success criteria:
+    - A PR exists in the repository with the scaffold for the idea.
+    - The Discord webhook received the notification message.
+    - The original Issue has a comment linking to the PR.
+
+  # -----------------------------------------------------------------
+  # Repositories — cloned fresh on every run; Claude pushes to
+  # claude/-prefixed branches unless unrestricted pushes are enabled.
+  # -----------------------------------------------------------------
+  repositories:
+    - repo: "${GITHUB_REPO}"          # e.g. your-org/your-monorepo
+      default_branch: main
+      allow_unrestricted_branch_pushes: false   # Claude pushes to claude/* branches
+
+  # -----------------------------------------------------------------
+  # Environment — variables injected at runtime; never hardcode values.
+  # Configure these in Claude Cloud environment settings:
+  #   https://claude.ai/code/routines (Settings > Environments)
+  # -----------------------------------------------------------------
+  environment:
+    variables:
+      DISCORD_WEBHOOK_URL: "${DISCORD_WEBHOOK_URL}"   # Discord Incoming Webhook URL
+      GITHUB_TOKEN: "${GITHUB_TOKEN}"                 # GitHub token with repo scope
+      GITHUB_REPO: "${GITHUB_REPO}"                   # owner/repo of the target repo
+
+  # -----------------------------------------------------------------
+  # Triggers — this routine uses a GitHub event trigger.
+  # Additional schedule or API triggers can be added in the web UI.
+  # -----------------------------------------------------------------
+  triggers:
+    - type: github
+      event: pull_request        # closest available; use "issues" when supported
+      # _note: As of research preview, supported GitHub events are
+      #        "pull_request" and "release". Issues webhook support
+      #        may be added in a future release. Until then, use the
+      #        API trigger below as the primary entry point.
+      repository: "${GITHUB_REPO}"
+      filters:
+        labels:
+          - idea
+        is_draft: false
+
+    # Alternative: API trigger — fire this routine from any system
+    # that can make an authenticated HTTP POST (e.g. a GitHub Actions
+    # workflow that fires when an Issue with label "idea" is opened).
+    #
+    # curl -X POST https://api.anthropic.com/v1/claude_code/routines/<ROUTINE_ID>/fire \
+    #   -H "Authorization: Bearer ${ROUTINE_API_TOKEN}" \
+    #   -H "anthropic-beta: experimental-cc-routine-2026-04-01" \
+    #   -H "anthropic-version: 2023-06-01" \
+    #   -H "Content-Type: application/json" \
+    #   -d '{"text": "Issue #42: A social network for cats"}'
+    - type: api
+      _note: >
+        API token is generated after the routine is saved in the web UI.
+        Store the token as ROUTINE_API_TOKEN in your secret store.
+        The ROUTINE_ID is visible in the routine's detail page URL.
+
+  # -----------------------------------------------------------------
+  # Connectors — MCP connectors included in every run.
+  # Remove any that this routine does not need to limit surface area.
+  # -----------------------------------------------------------------
+  connectors:
+    - github     # required for cloning, PR creation, and Issue comments
+    # - slack    # optional: add if you prefer Slack over Discord webhook
+    # - linear   # optional: add for issue tracker integration
+
+  # -----------------------------------------------------------------
+  # Daily quota reminder (as of 2026-04-14 research preview)
+  # Pro: 5 runs/day | Max: 15/day | Team/Enterprise: 25/day
+  # Extra runs available with additional usage (Settings > Billing).
+  # -----------------------------------------------------------------
+  _quota_note: >
+    Each run of this routine counts as 1 toward your daily routine limit.
+    With Pro (5/day), plan accordingly if you expect bursts of new ideas.
+    Upgrade to Max or Team for higher throughput.


### PR DESCRIPTION
## 무엇을 바꿨나

Claude Code Routines (2026-04-14) 통합 스캐폴드.

- `templates/routines/idea-to-mvp.yaml` (119줄): 참고 템플릿
- `templates/routines/README.md` (153줄, 한국어)
- `docs/routines-integration.md` (318줄, 한·영): end-to-end 플로우 + GitHub Actions 브릿지
- `ARCHITECTURE.md`: Routines를 Adopted 서브섹션으로 승격
- `sync-manifest.json`: 2 managed entries

## 왜 바꿨나

\"로컬 ralph\" 구조의 한계 극복: 대표가 맥북·터미널 없이 디코에 아이디어 한 줄만 던지면 서버 자동 빌드 → PR + 결과 알림. 경쟁 차별화 핵심.

## 어떻게 검증했나

- [x] 하드코딩 시크릿 0건 (grep 검증, \${DISCORD_WEBHOOK_URL} 등 placeholder만)
- [x] Routines 공식 문서 2곳 참조 (launch post + reference docs)
- [x] 스키마 미정 영역은 \`_note\`로 명시
- [x] install.sh / SKILL.md / phases.md / LICENSE / README / CLAUDE.md 무변경

## 구조적 결정

- **YAML은 참고 템플릿**: 공식 Routines는 web UI / `/schedule` CLI로만 등록, 파일 기반 스키마 없음
- **GitHub Actions 브릿지**: Issues는 네이티브 trigger 아님 → \`issues.opened\` 워크플로우가 Routine API 호출
- **bilingual 가이드**: 한국어 CEO + 영어 개발자 양쪽 독자 대응 → 통합 가이드 318줄 (목표 100~180 초과는 bilingual 특성)

## 다운스트림 영향

- [x] 템플릿 추가 (\`templates/routines/\`)
- [x] \`sync-manifest.json\` 갱신 완료
- [x] 다음 sync 주기에 downstream 전파
- [ ] 마이그레이션 문서 (opt-in이라 불필요)

## 체크리스트

- [x] 한국어 원자적 커밋 (\`feat:\`)
- [x] 관련 Issue: #29
- [x] 문서 동기화 (ARCHITECTURE.md)
- [x] .env / 시크릿 없음

Resolves #29