### PR TITLE
feat: Agent Teams + worktree 프리셋 (#30)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -279,9 +279,25 @@ Extra runs available via Settings > Billing (metered overage).
 - GitHub Issues event not yet a native trigger; bridge via GitHub Actions + API trigger
 - Each run is a fresh session; inter-run state must be passed via committed files
 
+### Agent Teams + Worktree (Parallel Workers)
+
+Shipped on `feature/#30-agent-teams`. Scaffold merged into `templates/agent-teams/`.
+
+- **Status**: scaffold shipped — see `templates/agent-teams/`
+- **Activation**: `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` (env or `settings.json`)
+- **Minimum version**: Claude Code v2.1.32+
+- **Two presets**: `web-app-team` (frontend + backend + test workers), `cron-bot-team` (logic + scheduler + monitoring workers)
+- **Runtime coordination**: teams are not pre-authored YAML configs. The team lead creates teams via natural language; runtime state is saved to `~/.claude/teams/{team-name}/config.json` automatically.
+- **Subagent reuse**: each worker references an existing `templates/agents/` definition via `agent_type`. The agent's `tools` allowlist and `model` are applied; its body is appended as additional system prompt instructions.
+- **File conflict prevention**: each worker owns a distinct set of paths (`owned_paths`). Two workers editing the same file causes overwrites — the spawn prompt must enforce boundaries.
+- **Inter-teammate messaging**: workers message each other directly (not only through the lead) via `message` (one teammate) or `broadcast` (all teammates). Costs scale with team size.
+- **Known constraint**: all teammates share one model at spawn time. Model mixing (Opus for architecture) must be handled in the main lead session via subagents, not as a teammate.
+- **Experimental warning**: API surface and behavior subject to change without notice.
+
+See `templates/agent-teams/README.md` for Korean activation guide and usage decision matrix.
+
 ### Planned Adoptions (Week 3+ backlog)
 
-- **Agent Teams + Worktree**: parallel workers across isolated worktrees, coordinated by a team-leader session. Requires `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`.
 - **Plugin Marketplace**: package idea-factory as an official plugin (`anthropics/claude-plugins-official`) for one-command install.
 
 ---

--- a/sync-manifest.json
+++ b/sync-manifest.json
@@ -28,7 +28,10 @@
     { "src": "templates/mcp/README.md",                           "dst": ".claude/mcp/README.md" },
     { "src": "templates/mcp/merge-example.sh",                    "dst": ".claude/mcp/merge-example.sh" },
     { "src": "templates/routines/idea-to-mvp.yaml",               "dst": ".claude/routines/idea-to-mvp.yaml" },
-    { "src": "templates/routines/README.md",                      "dst": ".claude/routines/README.md" }
+    { "src": "templates/routines/README.md",                      "dst": ".claude/routines/README.md" },
+    { "src": "templates/agent-teams/web-app-team.yaml",           "dst": ".claude/agent-teams/web-app-team.yaml" },
+    { "src": "templates/agent-teams/cron-bot-team.yaml",          "dst": ".claude/agent-teams/cron-bot-team.yaml" },
+    { "src": "templates/agent-teams/README.md",                   "dst": ".claude/agent-teams/README.md" }
   ],
   "computed": [
     { "generator": "merge-settings", "dst": ".claude/settings.json", "note": "base + type extension 병합 결과와 비교" }

--- a/templates/agent-teams/README.md
+++ b/templates/agent-teams/README.md
@@ -1,0 +1,163 @@
+# Agent Teams 가이드
+
+> **실험 기능 경고**: Agent Teams는 2026년 초 실험적으로 출시된 기능이다.
+> API 및 동작 방식이 예고 없이 변경될 수 있다. 프로덕션 크리티컬 경로에는
+> 사용 전 안정화 여부를 확인할 것.
+> 공식 문서: https://code.claude.com/docs/en/agent-teams
+
+---
+
+## Agent Teams란 무엇인가
+
+Agent Teams는 여러 Claude Code 세션이 하나의 팀으로 협력하는 기능이다.
+
+- **팀 리드(Team Lead)**: 메인 Claude Code 세션. 팀을 생성하고 태스크를 배분하며 결과를 종합한다.
+- **팀원(Teammates)**: 각자 독립된 컨텍스트 윈도우를 가진 별도의 Claude Code 인스턴스. 병렬로 작업한다.
+- **공유 태스크 목록(Task List)**: 팀 전체가 공유하는 작업 큐. 팀원이 자율적으로 태스크를 클레임한다.
+- **메일박스(Mailbox)**: 팀원 간 직접 메시지 시스템. 리드를 거치지 않고 팀원끼리 소통 가능.
+
+기존 서브에이전트(subagent)와 달리, 팀원들은 서로 직접 메시지를 주고받으며
+공유 태스크 목록을 통해 자율 조정한다.
+
+---
+
+## 활성화 방법
+
+Agent Teams는 기본적으로 비활성화되어 있다. 두 가지 방법으로 활성화한다.
+
+### 방법 1 — 환경변수 설정
+
+```bash
+export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
+```
+
+### 방법 2 — settings.json에 추가 (권장)
+
+```json
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  }
+}
+```
+
+Claude Code v2.1.32 이상이 필요하다. 버전 확인: `claude --version`
+
+---
+
+## 팀 생성 방법
+
+설정 파일을 직접 작성하지 않는다. 팀은 **자연어 프롬프트로 생성**하며,
+설정은 런타임에 `~/.claude/teams/{team-name}/config.json`에 자동 저장된다.
+
+```text
+Create an agent team using the web-app-team preset:
+spawn a frontend-worker, backend-worker, and test-worker.
+Use Sonnet for each teammate.
+```
+
+이 레포의 YAML 프리셋 파일(`web-app-team.yaml`, `cron-bot-team.yaml`)은
+팀 리드가 참고하는 레퍼런스다. `suggested_lead_prompt` 섹션을 그대로 복사해
+팀 리드 세션에 붙여넣으면 된다.
+
+---
+
+## 이 레포의 프리셋
+
+| 파일 | 용도 | 워커 구성 |
+|---|---|---|
+| `web-app-team.yaml` | 웹 앱 MVP 병렬 빌드 | frontend + backend + test |
+| `cron-bot-team.yaml` | 크론 봇 자동화 빌드 | logic + scheduler + monitoring |
+
+각 워커는 기존 `templates/agents/` 단일 에이전트 정의를 `agent_type`으로 참조한다.
+워커를 spawn할 때 해당 에이전트의 `tools` 허용 목록과 `model`이 적용되며,
+에이전트 정의 본문이 팀원 시스템 프롬프트에 추가 지침으로 덧붙여진다.
+
+---
+
+## worktree 자동 분리
+
+Agent Teams는 `isolation: "worktree"` 설정 시 각 팀원이
+별도의 git worktree에서 작업하므로 파일 충돌이 원천적으로 방지된다.
+
+프리셋에서는 `owned_paths` 방식으로 파일 소유권을 명시해 충돌을 예방한다.
+동일 파일을 두 팀원이 편집하면 덮어쓰기 충돌이 발생하므로,
+각 팀원이 고유 경로 집합만 편집하도록 spawn 프롬프트에 명시한다.
+
+---
+
+## 팀 리드의 역할
+
+팀 리드는 다음을 담당한다:
+
+1. **태스크 목록 생성**: 전체 작업을 자기완결적 단위로 분해한다 (팀원당 5-6개 권장)
+2. **방향 결정**: 아키텍처 결정과 API 계약은 리드(Opus 권장)가 최종 확정
+3. **품질 게이트**: 스키마·인증 변경 전 계획 승인 요청 (`plan approval`)
+4. **합성**: 모든 팀원 완료 후 결과를 종합해 다음 단계로 전달
+5. **정리**: 작업 완료 후 `Clean up the team`으로 팀 리소스 해제
+
+---
+
+## 언제 Agent Teams를 사용할 것인가
+
+### 사용 권장
+
+- **MVP 병렬화**: 프론트엔드와 백엔드가 서로 독립적으로 진행 가능한 경우
+- **크로스 레이어 변경**: UI + API + 테스트가 각각 다른 파일 집합을 건드리는 경우
+- **병렬 리뷰**: 보안, 성능, 테스트 커버리지를 동시에 다른 시각으로 검토할 때
+- **경쟁 가설 디버깅**: 여러 팀원이 다른 이론을 독립적으로 검증할 때
+
+### 순차 유지 권장
+
+- **강한 커플링**: 팀원 A의 결과가 팀원 B의 입력인 경우 (병렬의 이점 없음)
+- **동일 파일 편집**: 같은 파일을 여러 팀원이 건드려야 하는 경우
+- **단순 반복 작업**: 조율 오버헤드가 이익보다 큰 소규모 작업
+- **비용 민감 구간**: 팀원 수만큼 토큰이 선형 증가함을 고려
+
+---
+
+## 팀원 간 소통 방법
+
+팀원은 두 가지 방식으로 소통한다:
+
+- **message**: 특정 팀원 1명에게 직접 메시지
+- **broadcast**: 모든 팀원에게 동시 전송 (비용이 팀 규모에 비례하므로 최소화)
+
+사용자가 팀원에게 직접 메시지를 보내려면:
+
+- **in-process 모드**: `Shift+Down`으로 팀원 전환 후 입력
+- **split-pane 모드**: tmux/iTerm2에서 해당 팀원 창을 클릭 후 입력
+
+---
+
+## 현재 알려진 한계
+
+Agent Teams는 실험 기능이므로 다음 제약이 있다:
+
+| 제약 | 내용 |
+|---|---|
+| 세션 재개 불가 | `/resume`, `/rewind`가 in-process 팀원을 복원하지 못함 |
+| 모델 고정 | 모든 팀원이 동일 모델을 사용 (개별 지정 불가, spawn 시 자연어로만 전달 가능) |
+| 중첩 팀 불가 | 팀원이 하위 팀을 생성할 수 없음. 팀 리드만 팀 관리 가능 |
+| 팀당 1개 | 세션 하나에 팀 하나만 운영 가능 |
+| 태스크 상태 지연 | 팀원이 완료 마킹을 누락할 수 있음. 리드가 수동으로 nudge 필요 |
+| split-pane 제약 | tmux 또는 iTerm2 필요. VS Code 통합 터미널, Windows Terminal 미지원 |
+
+**모델 혼용이 필요한 경우**: 팀원은 현재 단일 모델로 제한된다.
+Opus가 필요한 아키텍처 결정은 팀 리드(main session)에서 subagent로 처리한다.
+
+---
+
+## 비용 주의
+
+팀원 수만큼 컨텍스트 윈도우가 독립적으로 열려 토큰 비용이 선형 증가한다.
+3-5명이 대부분의 워크플로에 적합하다. 루틴 작업은 단일 세션이 더 비용 효율적이다.
+
+---
+
+## 다운스트림 적용
+
+이 디렉터리의 파일은 `sync-manifest.json`에 `managed`로 등록되어 있다.
+`sync-downstream.sh`로 10개 다운스트림 레포에 전파된다.
+워커별 `spawn_prompt`의 `{{SERVICE_NAME}}` 플레이스홀더는
+SCAFFOLD 단계에서 실제 서비스명으로 치환된다.

--- a/templates/agent-teams/cron-bot-team.yaml
+++ b/templates/agent-teams/cron-bot-team.yaml
@@ -1,0 +1,137 @@
+# cron-bot-team.yaml
+#
+# Agent Teams 프리셋 — 크론 봇 / 자동화 파이프라인 병렬 빌드
+#
+# 사용법:
+#   팀 리드 세션(main /start-company)에서 자연어로 팀 생성을 요청한다.
+#   예: "Create an agent team using the cron-bot-team preset: spawn a
+#       logic-worker, scheduler-worker, and monitoring-worker."
+#
+# 전제 조건:
+#   CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 활성화 필요 (README.md 참조)
+#   Claude Code v2.1.32 이상
+#
+# _note: Agent Teams의 팀 설정(~/.claude/teams/)은 런타임에 자동 생성된다.
+#   이 파일은 YAML 프리셋 레퍼런스다. 팀 리드가 이 파일을 읽고
+#   spawn 프롬프트를 구성하는 데 참고한다.
+#   공식 문서: https://code.claude.com/docs/en/agent-teams
+
+team:
+  name: "cron-bot-team"
+  description: "크론 봇 자동화 병렬 빌드 — 핵심 로직·스케줄러·모니터링 독립 워커"
+  version: "1.0.0"
+
+  # 팀 리드: 메인 /start-company 세션 (Opus 4.7 권장 — 아키텍처 결정)
+  # 팀 리드는 TaskList를 관리하고 워커 간 API 계약을 조율한다.
+
+  teammates:
+    - id: "logic-worker"
+      description: "핵심 알고리즘·데이터 수집 로직 담당"
+      model: "claude-sonnet-4-6"
+      # templates/agents/developer.md 역할 정의 참조
+      agent_type: "developer"
+      spawn_prompt: |
+        You are the logic-worker for {{SERVICE_NAME}}.
+        Your responsibilities:
+        - Core algorithm implementation (signal generation, data transformation, business rules)
+        - External data fetching (API clients, websockets, file parsers)
+        - Data normalization and validation
+        - Stateless processing functions that scheduler-worker will call
+        Reference: .claude/agents/developer.md for development principles.
+        Work independently on files under src/logic/, src/fetchers/, src/parsers/, src/models/.
+        Do NOT touch cron config, scheduler files, or monitoring code.
+        When the core function interface is stable, message scheduler-worker with
+        the function signature so they can wire it into the cron schedule.
+        No hardcoded secrets — all API keys via process.env.
+        Include error types and retry-able vs fatal error classification.
+      owned_paths:
+        - "src/logic/"
+        - "src/fetchers/"
+        - "src/parsers/"
+        - "src/models/"
+        - "src/types/"
+
+    - id: "scheduler-worker"
+      description: "크론 설정·재시도·백오프 로직 담당"
+      model: "claude-sonnet-4-6"
+      # templates/agents/developer.md 역할 정의 참조
+      agent_type: "developer"
+      spawn_prompt: |
+        You are the scheduler-worker for {{SERVICE_NAME}}.
+        Your responsibilities:
+        - Cron schedule configuration (crontab syntax, timezone handling)
+        - Job runner and queue management
+        - Retry logic with exponential backoff
+        - Concurrency limits and job locking (prevent overlapping runs)
+        - Graceful shutdown handling (SIGTERM, SIGINT)
+        Reference: .claude/agents/developer.md for development principles.
+        Work independently on files under src/scheduler/, src/jobs/, src/queue/, cron.*.
+        Wait for logic-worker to stabilize the core function interface before wiring.
+        When retry/backoff parameters are set, message monitoring-worker so they
+        can configure alert thresholds to match.
+        No hardcoded cron secrets or API keys.
+        Document the expected execution window and SLA for each job.
+      owned_paths:
+        - "src/scheduler/"
+        - "src/jobs/"
+        - "src/queue/"
+        - "cron.*"
+        - "src/runner/"
+
+    - id: "monitoring-worker"
+      description: "헬스 체크·알림·메트릭 담당"
+      model: "claude-sonnet-4-6"
+      # templates/agents/developer.md + qa-tester.md 역할 참조
+      agent_type: "developer"
+      spawn_prompt: |
+        You are the monitoring-worker for {{SERVICE_NAME}}.
+        Your responsibilities:
+        - Health check endpoints (liveness, readiness)
+        - Alerting integration (Discord, Slack, email — via env vars, no hardcoded webhooks)
+        - Metrics collection (job success rate, latency, error counts)
+        - Dead-letter queue handling and failure reporting
+        - Log structuring (JSON logs with correlation IDs)
+        Reference: .claude/agents/developer.md and .claude/agents/qa-tester.md.
+        Work independently on files under src/monitoring/, src/health/, src/alerts/, src/metrics/.
+        Wait for scheduler-worker to define retry parameters before setting alert thresholds.
+        All webhook URLs and notification tokens via process.env — never hardcoded.
+        Structure logs so they are parseable by standard log aggregators (Datadog, CloudWatch).
+      owned_paths:
+        - "src/monitoring/"
+        - "src/health/"
+        - "src/alerts/"
+        - "src/metrics/"
+        - "src/logs/"
+
+  # 실행 순서 의존성 (소프트 의존 — 팀 리드가 조율)
+  dependency_notes:
+    - "logic-worker가 핵심 함수 인터페이스를 확정한 후 scheduler-worker가 연결"
+    - "scheduler-worker가 재시도 파라미터를 확정한 후 monitoring-worker가 임계값 설정"
+    - "세 워커는 동시 작업 가능 — 초기 구조 설계 후 인터페이스 계약을 메시지로 공유"
+
+  # 태스크 크기 가이드라인 (공식 문서 권장)
+  task_guidelines:
+    size: "self-contained unit producing a clear deliverable (fetcher function, job runner, health endpoint)"
+    tasks_per_teammate: "5-6 tasks keeps workers productive without excessive context switching"
+    avoid: "same-file edits by multiple teammates — assign by owned_paths above"
+
+  # 파일 충돌 방지 전략
+  isolation:
+    strategy: "owned_paths"
+    note: |
+      각 워커가 고유 경로 집합을 소유한다. 공유 설정 파일(예: config.ts)은
+      팀 리드가 단독으로 편집하거나 logic-worker에게 위임하고 변경 시 메시지로 공지한다.
+
+  # 권장 팀 리드 프롬프트 (start-company 세션에서 그대로 사용 가능)
+  suggested_lead_prompt: |
+    Create an agent team for {{SERVICE_NAME}} using the cron-bot-team preset.
+    Spawn three teammates using Sonnet for each:
+    1. logic-worker — core algorithm and data fetching (owns src/logic/, src/fetchers/)
+    2. scheduler-worker — cron config, retry, backoff (owns src/scheduler/, src/jobs/)
+    3. monitoring-worker — health checks and alerting (owns src/monitoring/, src/health/)
+    Workers should start in parallel. logic-worker messages scheduler-worker when
+    the core function interface is stable. scheduler-worker messages monitoring-worker
+    when retry parameters are finalized.
+    Require plan approval before any worker makes changes to shared config files.
+    No hardcoded secrets in any file — all credentials via process.env.
+    Wait for all teammates to finish before synthesizing results.

--- a/templates/agent-teams/web-app-team.yaml
+++ b/templates/agent-teams/web-app-team.yaml
@@ -1,0 +1,124 @@
+# web-app-team.yaml
+#
+# Agent Teams 프리셋 — 웹 애플리케이션 MVP 병렬 빌드
+#
+# 사용법:
+#   팀 리드 세션(main /start-company)에서 자연어로 팀 생성을 요청한다.
+#   예: "Create an agent team using the web-app-team preset: spawn a
+#       frontend-worker, backend-worker, and test-worker."
+#
+# 전제 조건:
+#   CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 활성화 필요 (README.md 참조)
+#   Claude Code v2.1.32 이상
+#
+# _note: Agent Teams의 팀 설정(~/.claude/teams/)은 런타임에 자동 생성된다.
+#   이 파일은 YAML 프리셋 레퍼런스다. 팀 리드가 이 파일을 읽고
+#   spawn 프롬프트를 구성하는 데 참고한다.
+#   공식 문서: https://code.claude.com/docs/en/agent-teams
+#
+# _note: 워커별 모델 지정은 현재 spawn 시점 자연어로 전달한다.
+#   ("Use Sonnet for each teammate") 런타임 config에는 모델이 자동 기록된다.
+
+team:
+  name: "web-app-team"
+  description: "웹 앱 MVP 병렬 빌드 — 프론트엔드·백엔드·테스트 독립 워커"
+  version: "1.0.0"
+
+  # 팀 리드: 메인 /start-company 세션 (Opus 4.7 권장 — 아키텍처 결정)
+  # 팀 리드는 TaskList를 관리하고 방향을 결정한다.
+  # 워커들은 리드에게만 보고하지 않고 서로 직접 메시지를 주고받을 수 있다.
+
+  teammates:
+    - id: "frontend-worker"
+      description: "UI 컴포넌트, 폼, 스타일링 담당"
+      model: "claude-sonnet-4-6"
+      # templates/agents/designer.md 역할 정의 참조
+      agent_type: "designer"
+      spawn_prompt: |
+        You are the frontend-worker for {{SERVICE_NAME}}.
+        Your responsibilities:
+        - UI components, forms, and styling
+        - Design system consistency
+        - Client-side state management
+        - Responsive layout and accessibility
+        Reference: .claude/agents/designer.md for design principles.
+        Work independently on files under src/components/, src/pages/, src/styles/.
+        Do NOT touch src/api/, src/server/, or test files — those belong to other teammates.
+        When your work depends on an API contract, message backend-worker directly.
+      owned_paths:
+        - "src/components/"
+        - "src/pages/"
+        - "src/styles/"
+        - "src/hooks/"
+        - "public/"
+
+    - id: "backend-worker"
+      description: "API 라우트, DB 스키마, 인증 로직 담당"
+      model: "claude-sonnet-4-6"
+      # templates/agents/developer.md 역할 정의 참조
+      agent_type: "developer"
+      spawn_prompt: |
+        You are the backend-worker for {{SERVICE_NAME}}.
+        Your responsibilities:
+        - API routes and endpoint implementation
+        - Database schema design and migrations
+        - Authentication and authorization logic
+        - Server-side validation and error handling
+        Reference: .claude/agents/developer.md for development principles.
+        Work independently on files under src/api/, src/server/, src/db/, src/auth/.
+        Do NOT touch src/components/, src/pages/, or test files — those belong to other teammates.
+        When the API contract is ready, message frontend-worker so they can integrate.
+        No hardcoded secrets — use process.env for all credentials.
+      owned_paths:
+        - "src/api/"
+        - "src/server/"
+        - "src/db/"
+        - "src/auth/"
+        - "src/lib/"
+
+    - id: "test-worker"
+      description: "유닛·통합·Playwright E2E 테스트 담당"
+      model: "claude-sonnet-4-6"
+      # templates/agents/qa-tester.md 역할 정의 참조
+      agent_type: "qa-tester"
+      spawn_prompt: |
+        You are the test-worker for {{SERVICE_NAME}}.
+        Your responsibilities:
+        - Unit tests for utility functions and business logic
+        - Integration tests for API routes
+        - Playwright E2E tests for critical user flows
+        Reference: .claude/agents/qa-tester.md for testing principles.
+        Work independently on files under src/__tests__/, tests/, e2e/.
+        Monitor what frontend-worker and backend-worker complete, then write
+        tests against those implementations. Message teammates if you find
+        a defect — they should fix it before you mark the test as blocked.
+      owned_paths:
+        - "src/__tests__/"
+        - "tests/"
+        - "e2e/"
+        - "playwright.config.*"
+
+  # 태스크 크기 가이드라인 (공식 문서 권장)
+  task_guidelines:
+    size: "self-contained unit producing a clear deliverable (function, component, route, test file)"
+    tasks_per_teammate: "5-6 tasks keeps workers productive without excessive context switching"
+    avoid: "same-file edits by multiple teammates — assign by owned_paths above"
+
+  # 파일 충돌 방지 전략
+  isolation:
+    strategy: "owned_paths"
+    note: |
+      각 워커가 고유 경로 집합을 소유한다. 동일 파일을 두 워커가 편집하면
+      덮어쓰기 충돌이 발생한다. 경계가 불명확한 파일(예: types.ts)은
+      팀 리드가 조정하거나 공유 파일로 지정해 선착순 편집 후 메시지로 알린다.
+
+  # 권장 팀 리드 프롬프트 (start-company 세션에서 그대로 사용 가능)
+  suggested_lead_prompt: |
+    Create an agent team for {{SERVICE_NAME}} using the web-app-team preset.
+    Spawn three teammates using Sonnet for each:
+    1. frontend-worker — UI components, forms, styling (owns src/components/, src/pages/, src/styles/)
+    2. backend-worker — API routes, DB schema, auth (owns src/api/, src/server/, src/db/)
+    3. test-worker — unit, integration, Playwright E2E tests (owns tests/, e2e/)
+    Each teammate owns separate directories to prevent file conflicts.
+    Require plan approval before any teammate makes schema or auth changes.
+    Wait for all teammates to finish before synthesizing results.


### PR DESCRIPTION
## 무엇을 바꿨나

Agent Teams + worktree 참고 프리셋 스캐폴드.

- `templates/agent-teams/web-app-team.yaml` (124줄): frontend / backend / test 3 워커
- `templates/agent-teams/cron-bot-team.yaml` (137줄): logic / scheduler / monitoring 3 워커
- `templates/agent-teams/README.md` (163줄, 한국어): 활성화·시나리오·한계
- `ARCHITECTURE.md`: Agent Teams를 Adopted 서브섹션으로 승격
- `sync-manifest.json`: 3 managed entries

## 왜 바꿨나

순차 ralph 빌드 → 팀모드 전환 시 체감 5~10배 (커뮤니티 보고). 프론트-백엔드 독립성이 높은 web-app에서 효과 최대.

## 어떻게 검증했나

- [x] 공식 Agent Teams docs + Addy Osmani 블로그 교차 확인
- [x] \`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1\` 활성화 플래그 명시
- [x] 하드코딩 시크릿 0건 (grep)
- [x] templates/agents/ / skills/ / install.sh / LICENSE / README 무변경

## 구조적 결정

- **YAML = 참고 프리셋**: ~/.claude/teams/는 auto-generated (직접 편집 금지). YAML은 팀 리드의 spawn prompt 구성용 reference
- **teammate 모델 공유 한계**: 현재 Agent Teams는 팀 단일 모델. 모델 mix는 주 세션의 subagent 패턴으로 유지
- **기존 agents/ 참조**: 신규 팀 YAML이 \`templates/agents/\`의 단일 에이전트 템플릿을 참조 (역할 중복 방지)

## 다운스트림 영향

- [x] 템플릿 추가 (\`templates/agent-teams/\`)
- [x] \`sync-manifest.json\` 갱신 완료

## 체크리스트

- [x] 한국어 원자적 커밋 (\`feat:\`)
- [x] 관련 Issue: #30
- [x] 문서 동기화 (ARCHITECTURE.md)
- [x] .env / 시크릿 없음

Resolves #30