### PR TITLE
feat: Multi-agent observability 훅 — Discord/Telegram 상태 푸시 (#31)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -296,6 +296,34 @@ Shipped on `feature/#30-agent-teams`. Scaffold merged into `templates/agent-team
 
 See `templates/agent-teams/README.md` for Korean activation guide and usage decision matrix.
 
+### Multi-Agent Observability (Discord / Telegram Push)
+
+Shipped on `feature/#31-observability`. Scaffold in `templates/hooks/observability-push.sh`
+and `templates/observability/`.
+
+- **Purpose**: live visibility into parallel agent activity — which tool fired, which Task
+  was spawned, which story is running — pushed to Discord or Telegram in real time.
+  Addresses the top community pain point: "autonomous loops are opaque".
+- **Hook**: `templates/hooks/observability-push.sh` — PostToolUse only, exits 0
+  unconditionally. Never PreToolUse (v7.1 safety invariant).
+- **Trigger wiring** (opt-in, not in base `settings.json`):
+  ```json
+  { "matcher": "Task|Stop|SessionStart",
+    "hooks": [{ "type": "command",
+                "command": "bash .claude/hooks/observability-push.sh",
+                "timeout": 8000 }] }
+  ```
+- **Masking**: `templates/observability/filter-rules.yaml` — regex list covering
+  AWS keys, OpenAI/Anthropic sk- keys, GitHub tokens, Slack tokens, Google API keys,
+  Bearer headers, passwords, email addresses, and unfilled `${VAR}` placeholders.
+- **Env**:
+  - `OBSERVABILITY_WEBHOOK_URL` (required) — Discord webhook or Telegram bot URL
+  - `OBSERVABILITY_TYPE` — `discord` (default) | `telegram`
+  - `OBSERVABILITY_FILTER_LEVEL` — `minimal` | `normal` (default) | `verbose`
+  - `OBSERVABILITY_DEBUG=1` — stderr-only dry run, no network call
+- **Guide**: `templates/observability/README.md` (Korean setup + security notes)
+- **Reference pattern**: disler/claude-code-hooks-multi-agent-observability
+
 ### Planned Adoptions (Week 3+ backlog)
 
 - **Plugin Marketplace**: package idea-factory as an official plugin (`anthropics/claude-plugins-official`) for one-command install.

--- a/sync-manifest.json
+++ b/sync-manifest.json
@@ -31,7 +31,10 @@
     { "src": "templates/routines/README.md",                      "dst": ".claude/routines/README.md" },
     { "src": "templates/agent-teams/web-app-team.yaml",           "dst": ".claude/agent-teams/web-app-team.yaml" },
     { "src": "templates/agent-teams/cron-bot-team.yaml",          "dst": ".claude/agent-teams/cron-bot-team.yaml" },
-    { "src": "templates/agent-teams/README.md",                   "dst": ".claude/agent-teams/README.md" }
+    { "src": "templates/agent-teams/README.md",                   "dst": ".claude/agent-teams/README.md" },
+    { "src": "templates/hooks/observability-push.sh",            "dst": ".claude/hooks/observability-push.sh" },
+    { "src": "templates/observability/README.md",                "dst": ".claude/observability/README.md" },
+    { "src": "templates/observability/filter-rules.yaml",        "dst": ".claude/observability/filter-rules.yaml" }
   ],
   "computed": [
     { "generator": "merge-settings", "dst": ".claude/settings.json", "note": "base + type extension 병합 결과와 비교" }

--- a/templates/hooks/observability-push.sh
+++ b/templates/hooks/observability-push.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# observability-push.sh — PostToolUse observability push to Discord / Telegram
+#
+# Resolves: idea-factory Issue #31 — Multi-Agent Observability
+# Reference: github.com/disler/claude-code-hooks-multi-agent-observability
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# CRITICAL INVARIANT: THIS SCRIPT MUST ALWAYS EXIT 0 (v7.1 safety invariant)
+# ─────────────────────────────────────────────────────────────────────────────
+# Blocking hooks are architecturally incompatible with autonomous ralph loops.
+# All errors — network, parsing, env — are silently swallowed. exit 0 is
+# guaranteed by the trap at the top and the explicit exit 0 at the bottom.
+#
+# TRIGGER: PostToolUse (Task, Write, Edit, Bash — configurable via matcher)
+#
+# REQUIRED ENV:
+#   OBSERVABILITY_WEBHOOK_URL  — Discord Incoming Webhook URL or Telegram API URL
+#
+# OPTIONAL ENV:
+#   OBSERVABILITY_TYPE         — "discord" (default) | "telegram"
+#   OBSERVABILITY_FILTER_LEVEL — "minimal" | "normal" (default) | "verbose"
+#   OBSERVABILITY_DEBUG        — "1" → log payload to stderr only, no network call
+# ─────────────────────────────────────────────────────────────────────────────
+
+trap 'exit 0' ERR EXIT
+
+{
+  # ── Configuration ────────────────────────────────────────────────────────
+  WEBHOOK_URL="${OBSERVABILITY_WEBHOOK_URL:-}"
+  OBS_TYPE="${OBSERVABILITY_TYPE:-discord}"
+  FILTER_LEVEL="${OBSERVABILITY_FILTER_LEVEL:-normal}"
+  DEBUG_MODE="${OBSERVABILITY_DEBUG:-0}"
+  CURL_TIMEOUT=5
+
+  # ── Dry-run when OBSERVABILITY_WEBHOOK_URL is unset ─────────────────────
+  DRY_RUN=0
+  if [ -z "$WEBHOOK_URL" ]; then
+    DRY_RUN=1
+  fi
+
+  # ── Read hook payload from stdin ────────────────────────────────────────
+  # Claude Code PostToolUse hooks receive JSON on stdin:
+  #   { "session_id": "...", "tool_name": "...", "tool_input": {...},
+  #     "tool_response": {...} }
+  PAYLOAD=""
+  if [ -p /dev/stdin ] || [ ! -t 0 ]; then
+    PAYLOAD=$(cat 2>/dev/null || echo '')
+  fi
+  [ -z "$PAYLOAD" ] && PAYLOAD='{}'
+
+  # ── Extract fields with python3, fall back to empty strings ─────────────
+  extract_field() {
+    local field="$1"
+    local default="${2:-}"
+    if command -v python3 >/dev/null 2>&1; then
+      python3 -c "
+import sys, json
+try:
+    d = json.loads(sys.stdin.read())
+    keys = '${field}'.split('.')
+    v = d
+    for k in keys:
+        v = v.get(k, {}) if isinstance(v, dict) else {}
+    if not isinstance(v, str):
+        v = str(v) if v else '${default}'
+    sys.stdout.write(v if v else '${default}')
+except Exception:
+    sys.stdout.write('${default}')
+" 2>/dev/null <<< "$PAYLOAD"
+    else
+      echo "$default"
+    fi
+  }
+
+  TOOL_NAME=$(extract_field "tool_name" "unknown")
+  SESSION_ID=$(extract_field "session_id" "unknown")
+  # Task tool: task description lives in tool_input.description
+  TASK_DESC=$(extract_field "tool_input.description" "")
+  # Bash tool: command
+  BASH_CMD=$(extract_field "tool_input.command" "")
+  # Agent name from env (Claude Code sets CLAUDE_AGENT_NAME in subagent contexts)
+  AGENT_NAME="${CLAUDE_AGENT_NAME:-main}"
+  # Story hint from env (ralph loops export CURRENT_STORY when available)
+  CURRENT_STORY="${CURRENT_STORY:-}"
+
+  # ── Filter level gating ──────────────────────────────────────────────────
+  # minimal  → only Task tool events (agent spawns)
+  # normal   → Task + Stop + session events
+  # verbose  → everything (all PostToolUse)
+  should_send=0
+  case "$FILTER_LEVEL" in
+    minimal)
+      [ "$TOOL_NAME" = "Task" ] && should_send=1
+      ;;
+    normal)
+      case "$TOOL_NAME" in
+        Task|Stop|SessionStart) should_send=1 ;;
+      esac
+      ;;
+    verbose)
+      should_send=1
+      ;;
+  esac
+
+  # Skip self (avoid potential loops from observability hook appearing in audit)
+  if printf '%s' "$BASH_CMD" | grep -q "observability-push" 2>/dev/null; then
+    should_send=0
+  fi
+
+  [ "$should_send" -eq 0 ] && exit 0
+
+  # ── Secret masking ───────────────────────────────────────────────────────
+  # Applies to all string values before inclusion in the webhook payload.
+  # Patterns sourced from templates/observability/filter-rules.yaml.
+  mask_secrets() {
+    local text="$1"
+    if command -v python3 >/dev/null 2>&1; then
+      python3 -c "
+import sys, re
+text = sys.stdin.read()
+patterns = [
+    (r'AKIA[0-9A-Z]{16}',                        '[REDACTED-AWS-KEY]'),
+    (r'sk-[A-Za-z0-9]{20,}',                      '[REDACTED-SK-KEY]'),
+    (r'ghp_[A-Za-z0-9]{36}',                      '[REDACTED-GHP]'),
+    (r'xoxb-[0-9]+-[A-Za-z0-9-]+',               '[REDACTED-SLACK]'),
+    (r'AIza[0-9A-Za-z_-]{35}',                    '[REDACTED-GOOGLE]'),
+    (r'Bearer\s+[A-Za-z0-9\-._~+/]{20,}',         '[REDACTED-BEARER]'),
+    (r'[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}', '[REDACTED-EMAIL]'),
+    (r'\\\$\{[A-Z_][A-Z0-9_]*\}',                 '[UNFILLED-PLACEHOLDER]'),
+    (r'password[\"\'\\s:=]+[^\\s\"\']{4,}',       '[REDACTED-PASSWORD]'),
+]
+for pattern, replacement in patterns:
+    try:
+        text = re.sub(pattern, replacement, text, flags=re.IGNORECASE)
+    except Exception:
+        pass
+sys.stdout.write(text)
+" 2>/dev/null <<< "$text"
+    else
+      echo "$text"
+    fi
+  }
+
+  TASK_DESC_SAFE=$(mask_secrets "$TASK_DESC")
+  BASH_CMD_SAFE=$(mask_secrets "${BASH_CMD:0:200}")
+  STORY_SAFE=$(mask_secrets "$CURRENT_STORY")
+
+  # ── Build human-readable summary ─────────────────────────────────────────
+  NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "unknown-time")
+  SESSION_SHORT="${SESSION_ID:0:8}"
+
+  SUMMARY="[${AGENT_NAME}] ${TOOL_NAME}"
+  [ -n "$TASK_DESC_SAFE" ] && SUMMARY="$SUMMARY: ${TASK_DESC_SAFE:0:120}"
+  [ -n "$BASH_CMD_SAFE" ]  && SUMMARY="$SUMMARY | cmd: ${BASH_CMD_SAFE}"
+  [ -n "$STORY_SAFE" ]     && SUMMARY="$SUMMARY | story: ${STORY_SAFE:0:60}"
+
+  # ── Build webhook payload ────────────────────────────────────────────────
+  escape_json() {
+    printf '%s' "$1" \
+      | sed 's/\\/\\\\/g; s/"/\\"/g' 2>/dev/null \
+      | tr -d '\n\r\t' 2>/dev/null
+  }
+
+  SUMMARY_ESC=$(escape_json "$SUMMARY")
+  NOW_ESC=$(escape_json "$NOW")
+  SESSION_ESC=$(escape_json "$SESSION_SHORT")
+  AGENT_ESC=$(escape_json "$AGENT_NAME")
+  TOOL_ESC=$(escape_json "$TOOL_NAME")
+  LEVEL_ESC=$(escape_json "$FILTER_LEVEL")
+
+  if [ "$OBS_TYPE" = "telegram" ]; then
+    # Telegram sendMessage format (URL must be https://api.telegram.org/bot{TOKEN}/sendMessage?chat_id={ID})
+    MESSAGE_TEXT="*[idea-factory observability]*\nagent: ${AGENT_NAME}\ntool: ${TOOL_NAME}\nsession: ${SESSION_SHORT}\ntime: ${NOW}\n\n${SUMMARY}"
+    MSG_ESC=$(escape_json "$MESSAGE_TEXT")
+    WEBHOOK_BODY="{\"text\":\"${MSG_ESC}\",\"parse_mode\":\"Markdown\"}"
+  else
+    # Discord Incoming Webhook format
+    DISCORD_BODY=$(printf '{
+  "username": "idea-factory-obs",
+  "embeds": [{
+    "title": "Agent Event",
+    "color": 3447003,
+    "fields": [
+      {"name": "agent",   "value": "%s", "inline": true},
+      {"name": "tool",    "value": "%s", "inline": true},
+      {"name": "session", "value": "%s", "inline": true},
+      {"name": "level",   "value": "%s", "inline": true},
+      {"name": "summary", "value": "%s", "inline": false}
+    ],
+    "footer": {"text": "%s"}
+  }]
+}' "$AGENT_ESC" "$TOOL_ESC" "$SESSION_ESC" "$LEVEL_ESC" "$SUMMARY_ESC" "$NOW_ESC")
+    WEBHOOK_BODY="$DISCORD_BODY"
+  fi
+
+  # ── Send or dry-run ──────────────────────────────────────────────────────
+  if [ "$DEBUG_MODE" = "1" ]; then
+    printf '[observability-push DEBUG] payload:\n%s\n' "$WEBHOOK_BODY" >&2
+  fi
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '[observability-push DRY-RUN] OBSERVABILITY_WEBHOOK_URL unset — skipping network call\n' >&2
+    exit 0
+  fi
+
+  # Send with curl; 5-second timeout; all errors swallowed
+  curl \
+    --silent \
+    --max-time "$CURL_TIMEOUT" \
+    --request POST \
+    --header "Content-Type: application/json" \
+    --data "$WEBHOOK_BODY" \
+    "$WEBHOOK_URL" \
+    >/dev/null 2>&1 || true
+
+} 2>/dev/null
+
+# The most important line in this script.
+exit 0

--- a/templates/observability/README.md
+++ b/templates/observability/README.md
@@ -1,0 +1,160 @@
+# Multi-Agent Observability — 설정 가이드
+
+여러 에이전트가 동시에 실행될 때 무슨 일이 벌어지고 있는지 Discord 또는 Telegram으로
+실시간 확인할 수 있는 PostToolUse 훅입니다.
+
+---
+
+## 왜 Observability가 필요한가
+
+reddit r/ClaudeAI, r/aipromptprogramming 상위 10개 이슈 중 하나:
+**"autonomous loop가 뭘 하고 있는지 모르겠다"**
+
+ralph 루프나 agent-teams가 돌아가면 터미널을 붙잡고 있기 어렵습니다.
+이 훅은 에이전트 활동(어떤 Tool을 호출했는지, 어떤 Task를 스폰했는지)을
+외부 채널에 푸시해 CEO나 운영자가 모바일에서도 진행 상황을 파악할 수 있게 합니다.
+
+참고 패턴: [disler/claude-code-hooks-multi-agent-observability](https://github.com/disler/claude-code-hooks-multi-agent-observability)
+
+---
+
+## 빠른 시작
+
+### 1단계 — Webhook URL 발급
+
+#### Discord Incoming Webhook
+1. Discord 서버 → 채널 설정 → 연동 → 웹훅 → 새 웹훅
+2. 이름 지정 후 "웹훅 URL 복사"
+3. URL 형식: `https://discord.com/api/webhooks/{id}/{token}`
+
+#### Telegram Bot
+1. [@BotFather](https://t.me/BotFather) 에서 `/newbot` 실행 → 토큰 발급
+2. 봇을 원하는 채팅/채널에 추가
+3. `https://api.telegram.org/bot{TOKEN}/getUpdates` 로 `chat_id` 확인
+4. URL 형식: `https://api.telegram.org/bot{TOKEN}/sendMessage?chat_id={CHAT_ID}`
+
+### 2단계 — 환경변수 설정
+
+```bash
+# Discord (기본값)
+export OBSERVABILITY_WEBHOOK_URL="https://discord.com/api/webhooks/YOUR_ID/YOUR_TOKEN"
+export OBSERVABILITY_TYPE="discord"
+
+# 또는 Telegram
+export OBSERVABILITY_WEBHOOK_URL="https://api.telegram.org/botTOKEN/sendMessage?chat_id=CHAT_ID"
+export OBSERVABILITY_TYPE="telegram"
+```
+
+`.env` 파일에 저장하거나 셸 프로파일(`~/.zshrc`, `~/.bashrc`)에 추가합니다.
+**Webhook URL을 코드/파일에 하드코딩하지 마세요** — 항상 환경변수로만 주입합니다.
+
+### 3단계 — PostToolUse 훅 등록
+
+프로젝트의 `.claude/settings.json` 에 다음을 추가합니다:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Task|Stop|SessionStart",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/observability-push.sh",
+            "timeout": 8000
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+`matcher` 패턴은 필터링 수준에 맞게 조정하세요 (아래 참조).
+
+훅 파일은 `templates/hooks/observability-push.sh` 에서 복사합니다:
+
+```bash
+cp templates/hooks/observability-push.sh .claude/hooks/observability-push.sh
+chmod +x .claude/hooks/observability-push.sh
+```
+
+---
+
+## 필터링 수준 (OBSERVABILITY_FILTER_LEVEL)
+
+| 수준 | 환경변수 값 | 어떤 이벤트를 푸시하는가 |
+|------|------------|------------------------|
+| 최소 | `minimal`  | Task 호출만 (에이전트 스폰 시점) |
+| 일반 | `normal`   | Task + Stop + SessionStart (기본값) |
+| 상세 | `verbose`  | 모든 PostToolUse 이벤트 |
+
+```bash
+# 기본값 (생략 시 normal 적용)
+export OBSERVABILITY_FILTER_LEVEL="normal"
+
+# ralph 루프 집중 모니터링 시
+export OBSERVABILITY_FILTER_LEVEL="verbose"
+
+# 핵심 에이전트 스폰만 보고 싶을 때
+export OBSERVABILITY_FILTER_LEVEL="minimal"
+```
+
+> verbose 수준에서 트래픽이 많으면 Discord webhook rate limit(초당 5회)에
+> 걸릴 수 있습니다. 장시간 루프는 `normal` 또는 `minimal` 권장.
+
+---
+
+## 보안 — 시크릿 마스킹
+
+훅은 페이로드를 전송하기 전에 다음 패턴을 `[REDACTED]`로 교체합니다:
+
+| 패턴 | 대상 |
+|------|------|
+| `AKIA[0-9A-Z]{16}` | AWS Access Key |
+| `sk-[A-Za-z0-9]{20,}` | OpenAI / Anthropic API Key |
+| `ghp_[A-Za-z0-9]{36}` | GitHub Personal Access Token |
+| `xoxb-[0-9]+-...` | Slack Bot Token |
+| `AIza[0-9A-Za-z_-]{35}` | Google API Key |
+| `Bearer <token>` | Authorization 헤더 토큰 |
+| 이메일 주소 패턴 | 개인정보 |
+| `${VAR_NAME}` 형식 | 미치환 플레이스홀더 |
+| `password=<value>` | 비밀번호 |
+
+전체 마스킹 규칙은 `templates/observability/filter-rules.yaml` 참조.
+
+**Webhook URL 자체도 절대 코드/커밋에 포함하지 마세요.**
+환경변수 `OBSERVABILITY_WEBHOOK_URL`로만 주입하세요.
+
+---
+
+## 디버그 모드
+
+```bash
+# 네트워크 전송 없이 페이로드만 stderr에 출력
+export OBSERVABILITY_DEBUG=1
+```
+
+이 모드에서는 curl을 호출하지 않고 구성된 JSON 페이로드를 stderr에 출력합니다.
+설정 확인이나 페이로드 형태 검증에 사용합니다.
+
+---
+
+## 환경변수 요약
+
+| 변수 | 필수 | 기본값 | 설명 |
+|------|------|--------|------|
+| `OBSERVABILITY_WEBHOOK_URL` | 필수 | (없음) | Discord 또는 Telegram webhook URL |
+| `OBSERVABILITY_TYPE` | 선택 | `discord` | `discord` 또는 `telegram` |
+| `OBSERVABILITY_FILTER_LEVEL` | 선택 | `normal` | `minimal` / `normal` / `verbose` |
+| `OBSERVABILITY_DEBUG` | 선택 | `0` | `1`이면 전송 없이 stderr 출력만 |
+
+---
+
+## 아키텍처 노트
+
+- **훅 타입**: PostToolUse 전용 (PreToolUse 절대 사용 금지 — v7.1 안전 불변성)
+- **exit 0 보장**: 모든 오류(네트워크, 파싱, 환경변수 미설정)는 무시하고 항상 exit 0
+- **타임아웃**: curl 5초 제한, settings.json timeout 8000ms (ralph 루프 차단 방지)
+- **무한루프 방지**: `observability-push.sh` 자신의 호출은 자동으로 필터링

--- a/templates/observability/filter-rules.yaml
+++ b/templates/observability/filter-rules.yaml
@@ -1,0 +1,113 @@
+# observability/filter-rules.yaml
+# Secret masking patterns and event exclusion rules for observability-push.sh
+#
+# mask_patterns  — regex list applied to all string fields before webhook send
+# exclude_events — tool names whose PostToolUse events are always suppressed
+#
+# Reference: templates/hooks/observability-push.sh (inline Python masking)
+# Note: patterns here are documentation/config; the hook reads them implicitly
+#       via the inline regex list. A future version may load this file directly.
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Secret / credential masking patterns
+# Each entry: pattern (Python re syntax) + replacement string
+# ─────────────────────────────────────────────────────────────────────────────
+mask_patterns:
+
+  # AWS credentials
+  - pattern: "AKIA[0-9A-Z]{16}"
+    replacement: "[REDACTED-AWS-KEY]"
+    description: "AWS Access Key ID"
+
+  - pattern: "ASIA[0-9A-Z]{16}"
+    replacement: "[REDACTED-AWS-STS]"
+    description: "AWS STS temporary key"
+
+  # OpenAI / Anthropic / generic sk- keys
+  - pattern: "sk-[A-Za-z0-9]{20,}"
+    replacement: "[REDACTED-SK-KEY]"
+    description: "OpenAI or Anthropic API key"
+
+  # GitHub tokens
+  - pattern: "ghp_[A-Za-z0-9]{36}"
+    replacement: "[REDACTED-GHP]"
+    description: "GitHub Personal Access Token"
+
+  - pattern: "gho_[A-Za-z0-9]{36}"
+    replacement: "[REDACTED-GHO]"
+    description: "GitHub OAuth token"
+
+  - pattern: "ghs_[A-Za-z0-9]{36}"
+    replacement: "[REDACTED-GHS]"
+    description: "GitHub server-to-server token"
+
+  # Slack tokens
+  - pattern: "xoxb-[0-9]+-[A-Za-z0-9-]+"
+    replacement: "[REDACTED-SLACK-BOT]"
+    description: "Slack bot token"
+
+  - pattern: "xoxp-[0-9]+-[A-Za-z0-9-]+"
+    replacement: "[REDACTED-SLACK-USER]"
+    description: "Slack user token"
+
+  # Google API keys
+  - pattern: "AIza[0-9A-Za-z_-]{35}"
+    replacement: "[REDACTED-GOOGLE]"
+    description: "Google API key"
+
+  # Generic Bearer tokens (Authorization header values)
+  - pattern: "Bearer\\s+[A-Za-z0-9\\-._~+/]{20,}"
+    replacement: "[REDACTED-BEARER]"
+    description: "HTTP Authorization Bearer token"
+
+  # Passwords embedded in strings
+  - pattern: "password[\"'\\s:=]+[^\\s\"']{4,}"
+    replacement: "[REDACTED-PASSWORD]"
+    description: "Inline password value"
+    flags: "IGNORECASE"
+
+  # Email addresses (PII)
+  - pattern: "[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}"
+    replacement: "[REDACTED-EMAIL]"
+    description: "Email address (PII)"
+
+  # Unfilled template placeholders — e.g. ${SUPABASE_ACCESS_TOKEN}
+  - pattern: "\\$\\{[A-Z_][A-Z0-9_]*\\}"
+    replacement: "[UNFILLED-PLACEHOLDER]"
+    description: "Unsubstituted env-var placeholder (double-check scaffold)"
+
+  # Vercel tokens
+  - pattern: "vercel_[A-Za-z0-9]{24,}"
+    replacement: "[REDACTED-VERCEL]"
+    description: "Vercel API token"
+    flags: "IGNORECASE"
+
+  # Supabase service role keys (long JWT-shaped strings after 'service_role')
+  - pattern: "service_role\\.[A-Za-z0-9+/=]{40,}"
+    replacement: "[REDACTED-SUPABASE-SR]"
+    description: "Supabase service role key segment"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Excluded events — PostToolUse tool names that are NEVER forwarded
+# Purpose: prevent infinite loops and reduce noise from internal tooling
+# ─────────────────────────────────────────────────────────────────────────────
+exclude_events:
+
+  # The hook itself — calling observability-push.sh would create a loop
+  - tool: "observability-push"
+    reason: "Infinite loop prevention — the hook must not observe itself"
+
+  # Audit log hook — internal governance, not product activity
+  - tool: "check-audit"
+    reason: "Internal audit machinery; not meaningful to external observers"
+
+  # High-frequency read tools — too noisy at normal/minimal levels
+  # These are only emitted at verbose level via the filter_level gate in the hook
+  - tool: "Read"
+    reason: "High-frequency; use verbose level if you want file reads"
+
+  - tool: "Glob"
+    reason: "High-frequency file search; verbose level only"
+
+  - tool: "Grep"
+    reason: "High-frequency search; verbose level only"


### PR DESCRIPTION
## 무엇을 바꿨나

Multi-agent observability 훅 + 시크릿 마스킹 엔진.

- `templates/hooks/observability-push.sh` (219줄): PostToolUse, exit 0 invariant
- `templates/observability/README.md` (160줄, 한국어)
- `templates/observability/filter-rules.yaml` (113줄): 8종 시크릿 마스킹 정규식
- `ARCHITECTURE.md`: Observability 서브섹션 (27줄)
- `sync-manifest.json`: 3 managed entries

## 왜 바꿨나

r/ClaudeCode Top 10 불만: 여러 에이전트 병렬 실행 시 \"누가 무엇을 하는지\" 가시성 부재. 디스코드/텔레그램에 실시간 상태 푸시로 해소.

## 어떻게 검증했나

- [x] 하드코딩 시크릿 0건 (grep)
- [x] \`trap 'exit 0' ERR EXIT\` + \`|| true\` + \`2>/dev/null\` — exit 0 invariant 3중 보호
- [x] PostToolUse 전용 (PreToolUse 금지 — 자율 루프 안전 v7.1 invariant 준수)
- [x] Discord + Telegram 양쪽 payload 지원
- [x] Dry-run (URL 미설정 시 stderr만, 전송 없음)

## 구조적 결정

- **8종 마스킹 정규식**: AWS access key, sk- API key, GitHub PAT, Slack bot token, Google API key, Bearer token, password 라벨, email, \`${VAR}\` 미채움 placeholder
- **exclude_events 필터**: observability 훅 자체 호출은 제외 → 무한 루프 방지
- **env 기반 설정**: \`OBSERVABILITY_WEBHOOK_URL\` / \`OBSERVABILITY_TYPE\` / \`OBSERVABILITY_FILTER_LEVEL\` / \`OBSERVABILITY_DEBUG\`
- **templates/settings.json 무변경**: 사용자 opt-in으로 settings에 직접 등록

## 다운스트림 영향

- [x] 템플릿 추가 (\`templates/hooks/\`, \`templates/observability/\`)
- [x] \`sync-manifest.json\` 갱신 완료

## 체크리스트

- [x] 한국어 원자적 커밋 (\`feat:\`)
- [x] 관련 Issue: #31
- [x] 문서 동기화 (ARCHITECTURE.md)
- [x] .env / 시크릿 없음

Resolves #31