### PR TITLE
fix: install.sh + SCAFFOLD에 신규 템플릿 디렉터리 5종 포함 (#36)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -24,21 +24,22 @@ else
   }
 fi
 
-# Create directories
+# Create target directories
 mkdir -p "$SKILL_DIR"
-mkdir -p "$TEMPLATE_DIR"/{agents,hooks,documents}
+mkdir -p "$TEMPLATE_DIR"
 
-# Install skill
+# Install skill (entry point + Skills 2.0 progressive-disclosure detail files)
 cp "$SOURCE_DIR/skills/start-company/SKILL.md" "$SKILL_DIR/SKILL.md"
+[ -f "$SOURCE_DIR/skills/start-company/phases.md" ] && cp "$SOURCE_DIR/skills/start-company/phases.md" "$SKILL_DIR/phases.md"
+[ -f "$SOURCE_DIR/skills/start-company/agents.md" ] && cp "$SOURCE_DIR/skills/start-company/agents.md" "$SKILL_DIR/agents.md"
 echo "   ✓ Skill installed: /start-company"
 
-# Install templates
-cp "$SOURCE_DIR/templates/CLAUDE.md.tmpl" "$TEMPLATE_DIR/"
-cp "$SOURCE_DIR/templates/settings.json" "$TEMPLATE_DIR/"
-cp "$SOURCE_DIR/templates/agents/"*.md "$TEMPLATE_DIR/agents/"
-cp "$SOURCE_DIR/templates/hooks/"*.sh "$TEMPLATE_DIR/hooks/"
-cp "$SOURCE_DIR/templates/documents/"*.tmpl "$TEMPLATE_DIR/documents/"
-chmod +x "$TEMPLATE_DIR/hooks/"*.sh
+# Install templates (full tree — auto-picks up new subdirectories like
+# .claude/rules, mcp, routines, agent-teams, observability)
+cp -R "$SOURCE_DIR/templates/." "$TEMPLATE_DIR/"
+
+# Make all shell scripts executable (hooks, cron-bot scripts, mcp helpers, etc.)
+find "$TEMPLATE_DIR" -type f -name '*.sh' -exec chmod +x {} \;
 echo "   ✓ Templates installed: ~/.claude/templates/company/"
 
 # Cleanup temp dir if cloned

--- a/skills/start-company/phases.md
+++ b/skills/start-company/phases.md
@@ -80,7 +80,13 @@ Create project at `~/{folder-name}/`:
     - `scripts/health-check.sh` — JSON health status reporter
     - `templates/workflows/tuning-session.md` → `.project/tuning-protocol.md` (parameter tuning protocol)
     - `.omc/experiments/` directory with README from `templates/experiments/README.md`
-26. `git init` + `git config core.hooksPath .githooks` + initial commit
+26. **Optional extensions** (opt-in — copy verbatim into `.claude/`; user activates as needed):
+    - `.claude/rules/` — from `templates/.claude/rules/` (commit / security / code-style / ai-regression). Activate by uncommenting `@.claude/rules/*.md` at the bottom of `CLAUDE.md`.
+    - `.claude/mcp/` — from `templates/mcp/` (Supabase + Vercel OAuth 2.1 presets). Activate by running `bash .claude/mcp/merge-example.sh` to merge entries into `.claude/settings.json`.
+    - `.claude/routines/` — from `templates/routines/` (reference templates for Claude Code Routines). Register via Claude Code UI or `/schedule` CLI; local files are reference-only.
+    - `.claude/agent-teams/` — from `templates/agent-teams/` (web-app + cron-bot team presets). Activate with `export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` before session start.
+    - `.claude/observability/` — from `templates/observability/` (masking filter rules). Activate by wiring `.claude/hooks/observability-push.sh` into PostToolUse in `.claude/settings.json` and setting `OBSERVABILITY_WEBHOOK_URL`.
+27. `git init` + `git config core.hooksPath .githooks` + initial commit
 
 **Template variable reference**:
 - `{{SERVICE_NAME}}` — service name from analysis


### PR DESCRIPTION
## 무엇을 바꿨나

v8.1에서 추가된 5개 디렉터리가 install.sh의 명시적 cp 목록 + phases.md SCAFFOLD step에서 누락된 회귀 수정.

- **install.sh**: 특정 서브디렉터리 나열 `cp` → `cp -R templates/.` 전체 트리 복사. Skills 2.0 분할 파일(phases.md, agents.md)도 함께 설치. `chmod +x`를 `find` 재귀로 변경
- **phases.md SCAFFOLD STEP 2**: item 26에 Optional extensions 추가 — 5개 디렉터리 (.claude/rules, mcp, routines, agent-teams, observability)의 소스·타깃·활성화 방법 명시. git init은 item 27로 재번호

## 왜 바꿨나

`templates/CLAUDE.md.tmpl`의 `@.claude/rules/*.md` import 예시가 스캐폴드된 프로젝트에 `.claude/rules/`가 없으면 작동 불가. MCP/Routines/Agent Teams/Observability도 같은 문제 — 파일이 복사되지 않으면 사용자가 opt-in 할 수 없음.

## 어떻게 검증했나

- [x] \`bash -n install.sh\` 구문 체크 통과
- [x] install.sh이 \`cp -R templates/.\` 전체 복사로 변경
- [x] phases.md item 26이 5개 디렉터리 각각의 활성화 방법 명시
- [x] git init이 item 27로 재번호
- [x] SKILL.md / templates/ / 다른 스크립트 무변경
- [ ] 다운스트림에 실제 스캐폴드 smoke test (대표 확인)

## 다운스트림 영향

- [x] install.sh 변경 — 신규 설치 시 전체 템플릿 반영
- [x] phases.md 변경 — /start-company 실행 시 신규 프로젝트에 5개 옵션 디렉터리 자동 포함
- [x] 기존 스캐폴드된 프로젝트는 미영향 (retroactive 아님)
- [ ] 마이그레이션 문서 — 기존 프로젝트는 필요 시 수동으로 \`templates/\` 복사 가능

## 체크리스트

- [x] 한국어 원자적 커밋 (\`fix:\`)
- [x] 관련 Issue: #36
- [x] 구문 검증 통과
- [x] .env / 시크릿 없음

Resolves #36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능 및 개선 사항

* **New Features**
  * 선택적 Claude 확장 옵션 추가 (에이전트 팀, MCP, 루틴, 규칙, 옵저버빌리티)

* **Improvements**
  * 설치 프로세스 유연성 개선으로 새 디렉토리 자동 포함
  * 스킬 설치에 추가 선택적 파일 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->