### PR TITLE
feat: JSONL audit log grep/analyze tooling (#40)

### DIFF
--- a/docs/audit-analysis.md
+++ b/docs/audit-analysis.md
@@ -1,0 +1,169 @@
+# 감사 로그 분석 가이드 (Audit Log Analysis Guide)
+
+idea-factory v8 item 1.4 — `check-audit.sh`가 기록하는 JSONL 로그를
+검색·분석하는 두 도구의 사용법과 운영 지침.
+
+---
+
+## JSONL 스키마
+
+`check-audit.sh`가 `.claude/audit/YYYY-MM-DD.jsonl`에 기록하는 실제 필드:
+
+| 필드 | 타입 | 설명 |
+|---|---|---|
+| `ts` | string | ISO-8601 UTC 타임스탬프 (예: `2026-04-17T09:30:00Z`) |
+| `session` | string | Claude Code 세션 ID (`CLAUDE_SESSION_ID` 환경변수 값) |
+| `matcher` | string | 항상 `"Bash"` (PreToolUse Bash 매처 고정값) |
+| `tags` | string | 공백 구분 태그 목록 또는 빈 문자열. 가능한 값: `deploy` `redis-flush` `npm-install` `git-destructive` `rm-rf` |
+| `cmd` | string | 실행된 Bash 명령어 (최대 2048자, 초과 시 `...[truncated]` 추가) |
+
+**주의**: exit code 필드는 스키마에 없음. 명령 성공/실패 여부는 로그에서 확인 불가.
+
+---
+
+## 기본 사용법
+
+### 1. 오늘 감사 로그 전체 보기
+```bash
+bash scripts/audit-grep.sh
+```
+
+### 2. 최근 2시간 내 이벤트 검색
+```bash
+bash scripts/audit-grep.sh --since 2h
+```
+
+### 3. 특정 태그(deploy)가 포함된 이벤트 필터
+```bash
+bash scripts/audit-grep.sh --all --tool deploy
+```
+
+### 4. cmd 필드에서 정규식 패턴 검색
+```bash
+bash scripts/audit-grep.sh --since 1d --grep "npm install"
+```
+
+### 5. 특정 세션의 모든 이벤트 (원시 JSONL)
+```bash
+bash scripts/audit-grep.sh --all --session <SESSION_ID> --json
+```
+
+### 6. 오늘 가장 빈번한 명령어 상위 10개
+```bash
+bash scripts/audit-grep.sh --top 10
+```
+
+### 7. 전체 기간 세션별 요약 (이벤트 수 + 첫/마지막 시각)
+```bash
+bash scripts/audit-grep.sh --all --summary
+```
+
+### 8. 특정 날짜 로그 분석 리포트
+```bash
+bash scripts/audit-grep.sh --date 2026-04-15 | python3 scripts/audit-analyze.py --all
+```
+
+---
+
+## 분석 워크플로우
+
+두 도구는 단계적으로 사용한다.
+
+```
+.claude/audit/YYYY-MM-DD.jsonl
+         │
+         ▼
+  audit-grep.sh          ← 1단계: 원하는 이벤트 필터링
+  (jq 기반 검색)
+         │
+         ▼
+  audit-analyze.py       ← 2단계: 패턴 감지 및 리포트 생성
+  (Python 표준 라이브러리)
+```
+
+### 전형적인 체인 예시
+
+```bash
+# 전체 로그에서 이상 패턴 감지 리포트 생성
+python3 scripts/audit-analyze.py --all
+
+# 최근 24시간만 분석
+python3 scripts/audit-analyze.py --all --since 24h
+
+# JSON 형태로 출력 (CI 파이프라인 연동용)
+python3 scripts/audit-analyze.py --all --json
+
+# rm-rf 이벤트만 추출 후 상세 확인
+bash scripts/audit-grep.sh --all --tool rm-rf --json | jq '{ts,session,cmd}'
+```
+
+### `audit-analyze.py` 감지 패턴
+
+| 패턴 | 감지 기준 | 비고 |
+|---|---|---|
+| 반복 명령 (repeated-failure) | 동일 cmd가 세션 내 ≥3회 등장 | exit code 없어 실패 직접 판별 불가 — 재시도로 간주 |
+| 빈도 이상 (frequency-anomaly) | 세션 내 태그 빈도가 평균 대비 3σ 초과 | |
+| 보안 민감 패턴 (suspicious-pattern) | `rm -rf`, `sudo`, `curl | bash`, `.env` 등 정규식 매칭 | 의도적 사용일 수도 있음 — 컨텍스트 확인 필수 |
+
+---
+
+## 보안 주의사항
+
+감사 로그(`cmd` 필드)에는 다음이 포함될 수 있다:
+
+- 환경변수 값이 인자로 전달된 명령어
+- 파일 경로, 브랜치 이름, 임시 토큰
+- git commit 메시지, SQL 쿼리
+
+**공유 시 반드시 마스킹**:
+
+```bash
+# cmd 필드에서 민감 값 마스킹 후 공유
+bash scripts/audit-grep.sh --all --json \
+  | jq 'del(.cmd) + {cmd: "REDACTED"}' > safe-audit.jsonl
+```
+
+`.claude/audit/` 디렉터리는 `.gitignore`로 보호되어 있음 (`check-audit.sh`가 첫 실행 시 자동 생성).
+
+---
+
+## 운영 팁
+
+### 용량 관리
+
+감사 로그는 세션당 수백~수천 줄 기록될 수 있다. 월 1회 정도 정리를 권장.
+
+```bash
+# 30일 이전 로그 삭제
+find .claude/audit/ -name "*.jsonl" -mtime +30 -delete
+
+# 현재 로그 크기 확인
+du -sh .claude/audit/
+```
+
+### 로테이션
+
+자동 로테이션이 필요하면 cron 또는 logrotate 사용:
+
+```
+# crontab 예시: 매월 1일 오전 2시 90일 이전 로그 삭제
+0 2 1 * * find /path/to/project/.claude/audit/ -name "*.jsonl" -mtime +90 -delete
+```
+
+### 백업
+
+로그는 `.gitignore`로 커밋에서 제외되므로, 장기 보관이 필요하면 별도 백업 필요:
+
+```bash
+# 월별 아카이브
+tar -czf audit-$(date +%Y-%m).tar.gz .claude/audit/*.jsonl
+```
+
+### 환경변수 오버라이드
+
+`AUDIT_DIR` 환경변수로 로그 경로를 변경할 수 있다:
+
+```bash
+AUDIT_DIR=/var/log/claude-audit bash scripts/audit-grep.sh --all --summary
+AUDIT_DIR=/var/log/claude-audit python3 scripts/audit-analyze.py --all
+```

--- a/scripts/audit-analyze.py
+++ b/scripts/audit-analyze.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""audit-analyze.py — JSONL 감사 로그 패턴 감지 분석기
+
+idea-factory v8 item 1.4
+check-audit.sh 가 기록한 .claude/audit/YYYY-MM-DD.jsonl 파일을
+읽어 세 가지 패턴을 감지하고 Markdown 리포트를 출력한다.
+
+감지 패턴:
+  1. 반복 실패 (repeated-failure) — 동일 cmd가 세션 내 ≥3회 등장
+     NOTE: check-audit.sh 스키마에 exit code 필드가 없음.
+     따라서 실패를 직접 판별할 수 없다. 대신 동일 명령 반복 실행을
+     "잠재적 실패 재시도"로 간주하여 ≥3회 등장 시 플래그한다.
+  2. 빈도 이상 (frequency-anomaly) — 세션 평균 대비 3σ 초과 도구/태그
+  3. 보안 민감 패턴 (suspicious-pattern) — 위험 정규식 매칭 cmd
+
+Usage:
+  python3 scripts/audit-analyze.py [--dir DIR] [--since TIME] [--all]
+
+옵션:
+  --dir DIR      감사 로그 디렉터리 (기본: .claude/audit/ | AUDIT_DIR 환경변수)
+  --since TIME   시간 창 (예: 2h, 30m, 1d). 기본: 오늘 로그 전체
+  --all          모든 날짜 파일 스캔 (기본: 오늘만)
+  --json         Markdown 대신 JSON 출력
+  -h, --help     도움말
+"""
+
+import json
+import math
+import os
+import re
+import sys
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+# ── 보안 민감 패턴 목록 ──────────────────────────────────────────
+SUSPICIOUS_PATTERNS: list[tuple[str, str]] = [
+    (r"rm\s+-[a-zA-Z]*r[a-zA-Z]*f|rm\s+-[a-zA-Z]*f[a-zA-Z]*r", "rm -rf (재귀 강제 삭제)"),
+    (r"\bsudo\b", "sudo (권한 상승)"),
+    (r"curl\s+.*\|\s*(bash|sh)", "curl | bash (원격 코드 실행)"),
+    (r"wget\s+.*\|\s*(bash|sh)", "wget | bash (원격 코드 실행)"),
+    (r"\.env\b", ".env 파일 접근"),
+    (r"git\s+push\s+.*--force", "git force push"),
+    (r"git\s+reset\s+.*--hard", "git reset --hard"),
+    (r"redis-cli\s+(flushdb|flushall)", "Redis flush (전체 데이터 삭제)"),
+    (r"(AKIA[0-9A-Z]{8,}|sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{20,})", "시크릿 키 패턴"),
+    (r"chmod\s+777", "chmod 777 (과도한 권한)"),
+    (r">\s*/etc/", "/etc/ 덮어쓰기"),
+    (r"dd\s+if=.*of=", "dd 디스크 쓰기"),
+]
+
+# ── 반복 실패 임계값 ─────────────────────────────────────────────
+REPEAT_THRESHOLD = 3   # 동일 cmd 세션 내 N회 이상 → 플래그
+ANOMALY_SIGMA   = 3.0  # 빈도 이상 감지 σ
+
+
+def parse_since(since_str: str) -> datetime | None:
+    """'2h', '30m', '1d' 형식을 파싱해 cutoff datetime(UTC) 반환."""
+    if not since_str:
+        return None
+    m = re.fullmatch(r"(\d+)([smhd])", since_str)
+    if not m:
+        print(f"audit-analyze: --since 형식 오류: {since_str!r} (예: 2h, 30m, 1d)", file=sys.stderr)
+        sys.exit(2)
+    n, unit = int(m.group(1)), m.group(2)
+    seconds = {"s": 1, "m": 60, "h": 3600, "d": 86400}[unit]
+    return datetime.now(timezone.utc) - timedelta(seconds=n * seconds)
+
+
+def load_events(audit_dir: Path, all_files: bool, cutoff: datetime | None) -> list[dict]:
+    """JSONL 파일에서 이벤트를 로드한다."""
+    if not audit_dir.is_dir():
+        print(f"audit-analyze: 감사 로그 디렉터리가 없습니다: {audit_dir}", file=sys.stderr)
+        print("  Claude Code 세션을 한 번 실행하면 자동으로 생성됩니다.", file=sys.stderr)
+        sys.exit(0)
+
+    today = datetime.now().strftime("%Y-%m-%d")
+    if all_files:
+        files = sorted(audit_dir.glob("[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].jsonl"))
+    else:
+        target = audit_dir / f"{today}.jsonl"
+        files = [target] if target.exists() else []
+
+    if not files:
+        print(f"audit-analyze: 분석할 로그 파일이 없습니다 ({audit_dir})", file=sys.stderr)
+        sys.exit(0)
+
+    events: list[dict] = []
+    for f in files:
+        try:
+            for line in f.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    ev = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                # cutoff 필터
+                if cutoff and ev.get("ts"):
+                    try:
+                        ev_dt = datetime.strptime(ev["ts"], "%Y-%m-%dT%H:%M:%SZ").replace(
+                            tzinfo=timezone.utc
+                        )
+                        if ev_dt < cutoff:
+                            continue
+                    except ValueError:
+                        pass
+                events.append(ev)
+        except OSError:
+            pass
+
+    return events
+
+
+def detect_repeated_commands(events: list[dict]) -> list[dict]:
+    """세션 내 동일 cmd가 REPEAT_THRESHOLD회 이상 등장하는 경우를 감지.
+
+    NOTE: 스키마에 exit code 필드가 없으므로 실패를 직접 확인 불가.
+    동일 명령 반복 = 잠재적 재시도(실패 후 재실행)로 간주.
+    """
+    # {session: {cmd: count}}
+    from collections import defaultdict
+    session_cmd: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    for ev in events:
+        sess = ev.get("session", "unknown")
+        cmd = ev.get("cmd", "").strip()
+        if cmd:
+            session_cmd[sess][cmd] += 1
+
+    findings: list[dict] = []
+    for sess, cmds in session_cmd.items():
+        for cmd, cnt in cmds.items():
+            if cnt >= REPEAT_THRESHOLD:
+                findings.append({"session": sess, "cmd": cmd, "count": cnt})
+
+    findings.sort(key=lambda x: x["count"], reverse=True)
+    return findings
+
+
+def detect_frequency_anomalies(events: list[dict]) -> list[dict]:
+    """세션별 태그(도구) 빈도가 세션 평균 대비 3σ 초과인 경우 감지."""
+    from collections import defaultdict
+
+    # {session: {tag: count}}
+    session_tags: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    for ev in events:
+        sess = ev.get("session", "unknown")
+        tags_raw = ev.get("tags", "").strip()
+        if tags_raw:
+            for tag in tags_raw.split():
+                session_tags[sess][tag] += 1
+        else:
+            session_tags[sess]["(no-tag)"] += 1
+
+    findings: list[dict] = []
+    for sess, tag_counts in session_tags.items():
+        counts = list(tag_counts.values())
+        if len(counts) < 2:
+            continue
+        mean = sum(counts) / len(counts)
+        variance = sum((c - mean) ** 2 for c in counts) / len(counts)
+        sigma = math.sqrt(variance) if variance > 0 else 0
+        if sigma == 0:
+            continue
+        for tag, cnt in tag_counts.items():
+            z = (cnt - mean) / sigma
+            if z >= ANOMALY_SIGMA:
+                findings.append({
+                    "session": sess,
+                    "tag": tag,
+                    "count": cnt,
+                    "z_score": round(z, 2),
+                    "session_mean": round(mean, 2),
+                })
+
+    findings.sort(key=lambda x: x["z_score"], reverse=True)
+    return findings
+
+
+def detect_suspicious_patterns(events: list[dict]) -> list[dict]:
+    """cmd 필드에서 보안 민감 패턴을 정규식으로 감지."""
+    findings: list[dict] = []
+    for ev in events:
+        cmd = ev.get("cmd", "")
+        if not cmd:
+            continue
+        for pattern, label in SUSPICIOUS_PATTERNS:
+            if re.search(pattern, cmd, re.IGNORECASE):
+                findings.append({
+                    "ts": ev.get("ts", ""),
+                    "session": ev.get("session", "unknown"),
+                    "pattern": label,
+                    "cmd_preview": cmd[:200],
+                })
+    return findings
+
+
+def render_markdown(
+    repeated: list[dict],
+    anomalies: list[dict],
+    suspicious: list[dict],
+    event_count: int,
+) -> str:
+    """분석 결과를 Markdown으로 렌더링한다."""
+    now = datetime.now().strftime("%Y-%m-%d %H:%M")
+    lines: list[str] = [
+        "# 감사 로그 분석 리포트",
+        "",
+        f"생성: {now} | 분석 이벤트 수: {event_count}",
+        "",
+        "---",
+        "",
+    ]
+
+    # 1. 반복 명령
+    lines += [
+        "## 1. 반복 명령 (Repeated Commands)",
+        "",
+        f"> 동일 cmd가 세션 내 {REPEAT_THRESHOLD}회 이상 등장 = 잠재적 재시도 신호",
+        "> **주의**: 스키마에 exit code 필드가 없어 실패 여부를 직접 확인할 수 없습니다.",
+        "",
+    ]
+    if repeated:
+        lines.append("| 세션 | 횟수 | 명령어 (최대 120자) |")
+        lines.append("|---|---|---|")
+        for f in repeated:
+            sess = f["session"][:12]
+            cmd_preview = f["cmd"][:120].replace("|", "\\|")
+            lines.append(f"| `{sess}` | {f['count']} | `{cmd_preview}` |")
+    else:
+        lines.append("감지된 반복 명령 없음.")
+    lines.append("")
+
+    # 2. 빈도 이상
+    lines += [
+        "## 2. 빈도 이상 (Frequency Anomalies)",
+        "",
+        f"> 세션 내 태그 빈도가 평균 대비 {ANOMALY_SIGMA}σ 이상 초과",
+        "",
+    ]
+    if anomalies:
+        lines.append("| 세션 | 태그 | 횟수 | Z-Score | 세션 평균 |")
+        lines.append("|---|---|---|---|---|")
+        for f in anomalies:
+            sess = f["session"][:12]
+            lines.append(
+                f"| `{sess}` | `{f['tag']}` | {f['count']} | {f['z_score']} | {f['session_mean']} |"
+            )
+    else:
+        lines.append("감지된 빈도 이상 없음.")
+    lines.append("")
+
+    # 3. 보안 민감 패턴
+    lines += [
+        "## 3. 보안 민감 패턴 (Suspicious Patterns)",
+        "",
+        "> 아래 패턴은 의도적 사용일 수도 있습니다. 컨텍스트를 확인하세요.",
+        "",
+    ]
+    if suspicious:
+        lines.append("| 시각 | 세션 | 패턴 | 명령어 미리보기 |")
+        lines.append("|---|---|---|---|")
+        for f in suspicious:
+            sess = f["session"][:12]
+            cmd_preview = f["cmd_preview"][:100].replace("|", "\\|")
+            lines.append(f"| `{f['ts']}` | `{sess}` | {f['pattern']} | `{cmd_preview}` |")
+    else:
+        lines.append("감지된 보안 민감 패턴 없음.")
+    lines.append("")
+
+    lines += [
+        "---",
+        "",
+        "**보안 주의**: 감사 로그에는 민감한 명령어 인자가 포함될 수 있습니다.",
+        "이 리포트를 공유할 때 `cmd` 필드의 내용을 마스킹하세요.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def main() -> None:
+    audit_dir_str = os.environ.get("AUDIT_DIR", ".claude/audit")
+    since_str = ""
+    all_files = False
+    json_output = False
+
+    args = sys.argv[1:]
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in ("-h", "--help"):
+            print(__doc__)
+            return
+        elif arg == "--dir":
+            i += 1
+            if i >= len(args):
+                print("audit-analyze: --dir 에 값이 필요합니다", file=sys.stderr)
+                sys.exit(2)
+            audit_dir_str = args[i]
+        elif arg == "--since":
+            i += 1
+            if i >= len(args):
+                print("audit-analyze: --since 에 값이 필요합니다 (예: 2h)", file=sys.stderr)
+                sys.exit(2)
+            since_str = args[i]
+        elif arg == "--all":
+            all_files = True
+        elif arg == "--json":
+            json_output = True
+        else:
+            print(f"audit-analyze: 알 수 없는 옵션: {arg}", file=sys.stderr)
+            print("  사용법: python3 scripts/audit-analyze.py --help", file=sys.stderr)
+            sys.exit(2)
+        i += 1
+
+    audit_dir = Path(audit_dir_str)
+    cutoff = parse_since(since_str) if since_str else None
+
+    events = load_events(audit_dir, all_files, cutoff)
+
+    repeated   = detect_repeated_commands(events)
+    anomalies  = detect_frequency_anomalies(events)
+    suspicious = detect_suspicious_patterns(events)
+
+    if json_output:
+        result = {
+            "event_count": len(events),
+            "repeated_commands": repeated,
+            "frequency_anomalies": anomalies,
+            "suspicious_patterns": suspicious,
+        }
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        print(render_markdown(repeated, anomalies, suspicious, len(events)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/audit-grep.sh
+++ b/scripts/audit-grep.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# scripts/audit-grep.sh — JSONL 감사 로그 검색/필터 도구
+#
+# idea-factory v8 item 1.4 (감사 로그 post-session 분석 도구)
+# .claude/audit/YYYY-MM-DD.jsonl 파일을 jq로 쿼리한다.
+#
+# 사용법:
+#   bash scripts/audit-grep.sh [OPTIONS]
+#
+# 옵션:
+#   --dir DIR          감사 로그 디렉터리 (기본: .claude/audit/ | AUDIT_DIR 환경변수)
+#   --date YYYY-MM-DD  특정 날짜 (기본: 오늘)
+#   --all              AUDIT_DIR 하위 모든 YYYY-MM-DD.jsonl 스캔
+#   --since N{s,m,h,d} 최근 N초/분/시/일 내 이벤트 (예: --since 2h)
+#   --tool NAME        tags 필드에 NAME이 포함된 이벤트 (Bash, deploy, rm-rf 등)
+#   --grep PATTERN     cmd 필드에 PATTERN(정규식) 매칭 이벤트
+#   --session ID       session 필드가 ID인 이벤트
+#   --top N            가장 빈번한 명령어 상위 N개 집계 출력
+#   --summary          세션별 이벤트 수 + 첫/마지막 ts 요약
+#   --json             결과를 원시 JSONL로 출력 (기본: 1줄 요약 포맷)
+#   -h, --help         이 도움말 출력
+#
+# 종료 코드:
+#   0  결과 있음 또는 정상 빈 결과
+#   2  인자 오류
+#
+# 예시:
+#   bash scripts/audit-grep.sh --since 2h --grep "npm install"
+#   bash scripts/audit-grep.sh --all --tool rm-rf
+#   bash scripts/audit-grep.sh --date 2026-04-17 --session abc123 --json
+#   bash scripts/audit-grep.sh --all --top 10
+#   bash scripts/audit-grep.sh --all --summary
+
+# NOTE: -e 미사용 — --top/--summary 파이프 끝에서 비어도 nonzero 발생 방지
+set -uo pipefail
+
+# ── jq 필수 확인 ──────────────────────────────────────────────────
+if ! command -v jq >/dev/null 2>&1; then
+  echo "audit-grep: 오류 — jq가 설치되어 있지 않습니다." >&2
+  echo "  설치: brew install jq  또는  apt-get install jq" >&2
+  exit 2
+fi
+
+# ── 기본값 ────────────────────────────────────────────────────────
+AUDIT_DIR="${AUDIT_DIR:-.claude/audit}"
+DATE_TARGET="$(date +%Y-%m-%d 2>/dev/null || echo '')"
+ALL_FILES=0
+SINCE=""
+TOOL_FILTER=""
+GREP_PATTERN=""
+SESSION_FILTER=""
+TOP_N=""
+SUMMARY_MODE=0
+JSON_OUTPUT=0
+
+# ── 인자 파싱 ─────────────────────────────────────────────────────
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dir)
+      [ -z "${2-}" ] && { echo "audit-grep: --dir 에 값이 필요합니다" >&2; exit 2; }
+      AUDIT_DIR="$2"; shift 2 ;;
+    --date)
+      [ -z "${2-}" ] && { echo "audit-grep: --date 에 값이 필요합니다" >&2; exit 2; }
+      DATE_TARGET="$2"; shift 2 ;;
+    --all)
+      ALL_FILES=1; shift ;;
+    --since)
+      [ -z "${2-}" ] && { echo "audit-grep: --since 에 값이 필요합니다 (예: 2h)" >&2; exit 2; }
+      SINCE="$2"; shift 2 ;;
+    --tool)
+      [ -z "${2-}" ] && { echo "audit-grep: --tool 에 값이 필요합니다" >&2; exit 2; }
+      TOOL_FILTER="$2"; shift 2 ;;
+    --grep)
+      [ -z "${2-}" ] && { echo "audit-grep: --grep 에 패턴이 필요합니다" >&2; exit 2; }
+      GREP_PATTERN="$2"; shift 2 ;;
+    --session)
+      [ -z "${2-}" ] && { echo "audit-grep: --session 에 ID가 필요합니다" >&2; exit 2; }
+      SESSION_FILTER="$2"; shift 2 ;;
+    --top)
+      [ -z "${2-}" ] && { echo "audit-grep: --top 에 숫자가 필요합니다" >&2; exit 2; }
+      TOP_N="$2"; shift 2 ;;
+    --summary)
+      SUMMARY_MODE=1; shift ;;
+    --json)
+      JSON_OUTPUT=1; shift ;;
+    -h|--help)
+      sed -n '3,30p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *)
+      echo "audit-grep: 알 수 없는 옵션: $1" >&2
+      echo "  사용법: bash scripts/audit-grep.sh --help" >&2
+      exit 2 ;;
+  esac
+done
+
+# ── 감사 디렉터리 확인 ────────────────────────────────────────────
+if [ ! -d "$AUDIT_DIR" ]; then
+  echo "audit-grep: 감사 로그 디렉터리가 없습니다: $AUDIT_DIR" >&2
+  echo "  Claude Code 세션을 한 번 실행하면 자동으로 생성됩니다." >&2
+  exit 0
+fi
+
+# ── 대상 파일 목록 구성 ───────────────────────────────────────────
+if [ "$ALL_FILES" -eq 1 ]; then
+  # 모든 YYYY-MM-DD.jsonl 파일 (날짜순)
+  mapfile -t LOG_FILES < <(
+    find "$AUDIT_DIR" -maxdepth 1 -name '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].jsonl' \
+      2>/dev/null | sort
+  )
+else
+  LOG_FILES=("${AUDIT_DIR}/${DATE_TARGET}.jsonl")
+fi
+
+# 존재하는 파일만 걸러냄
+VALID_FILES=()
+for f in "${LOG_FILES[@]+"${LOG_FILES[@]}"}"; do
+  [ -f "$f" ] && VALID_FILES+=("$f")
+done
+
+if [ ${#VALID_FILES[@]} -eq 0 ]; then
+  if [ "$ALL_FILES" -eq 1 ]; then
+    echo "audit-grep: $AUDIT_DIR 에 JSONL 파일이 없습니다." >&2
+  else
+    echo "audit-grep: 로그 없음 — ${DATE_TARGET}.jsonl 파일이 없습니다." >&2
+  fi
+  exit 0
+fi
+
+# ── --since: 기준 타임스탬프 계산 ────────────────────────────────
+SINCE_EPOCH=0
+if [ -n "$SINCE" ]; then
+  num="${SINCE%[smhd]}"
+  unit="${SINCE: -1}"
+  if ! [[ "$num" =~ ^[0-9]+$ ]]; then
+    echo "audit-grep: --since 형식 오류 (예: 30m, 2h, 1d)" >&2
+    exit 2
+  fi
+  case "$unit" in
+    s) secs=$num ;;
+    m) secs=$((num * 60)) ;;
+    h) secs=$((num * 3600)) ;;
+    d) secs=$((num * 86400)) ;;
+    *) echo "audit-grep: --since 단위는 s/m/h/d 중 하나여야 합니다" >&2; exit 2 ;;
+  esac
+  SINCE_EPOCH=$(( $(date +%s) - secs ))
+fi
+
+# ── jq 필터 구성 ──────────────────────────────────────────────────
+# 각 조건을 select()로 연결
+build_filter() {
+  local f="."
+  local conditions=()
+
+  if [ "$SINCE_EPOCH" -gt 0 ]; then
+    # ts 필드를 epoch로 변환하여 비교
+    conditions+=("(.ts | strptime(\"%Y-%m-%dT%H:%M:%SZ\") | mktime) >= ${SINCE_EPOCH}")
+  fi
+
+  if [ -n "$TOOL_FILTER" ]; then
+    conditions+=("(.tags | test(\"${TOOL_FILTER}\"; \"i\"))")
+  fi
+
+  if [ -n "$GREP_PATTERN" ]; then
+    conditions+=("(.cmd | test(\"${GREP_PATTERN}\"; \"i\"))")
+  fi
+
+  if [ -n "$SESSION_FILTER" ]; then
+    conditions+=("(.session == \"${SESSION_FILTER}\")")
+  fi
+
+  if [ ${#conditions[@]} -gt 0 ]; then
+    local joined
+    joined="$(printf ' and %s' "${conditions[@]}")"
+    joined="${joined# and }"
+    f="select(${joined})"
+  fi
+
+  echo "$f"
+}
+
+JQ_FILTER="$(build_filter)"
+
+# ── 모드별 처리 ───────────────────────────────────────────────────
+
+# --top N: 빈도 집계
+if [ -n "$TOP_N" ]; then
+  if ! [[ "$TOP_N" =~ ^[0-9]+$ ]]; then
+    echo "audit-grep: --top 에는 양의 정수가 필요합니다" >&2
+    exit 2
+  fi
+  cat "${VALID_FILES[@]}" \
+    | jq -r "${JQ_FILTER} | .cmd" 2>/dev/null \
+    | sort | uniq -c | sort -rn \
+    | head -n "$TOP_N" \
+    | awk '{ cnt=$1; $1=""; cmd=substr($0,2); printf "%5d  %s\n", cnt, cmd }'
+  exit 0
+fi
+
+# --summary: 세션별 요약
+if [ "$SUMMARY_MODE" -eq 1 ]; then
+  cat "${VALID_FILES[@]}" \
+    | jq -r "${JQ_FILTER} | [.session, .ts] | @tsv" 2>/dev/null \
+    | sort \
+    | awk -F'\t' '
+      {
+        sess=$1; ts=$2
+        count[sess]++
+        if (!(sess in first)) first[sess]=ts
+        last[sess]=ts
+      }
+      END {
+        for (s in count)
+          printf "session=%-24s  events=%4d  first=%s  last=%s\n", s, count[s], first[s], last[s]
+      }
+    ' | sort
+  exit 0
+fi
+
+# 기본/--json 모드: 이벤트 출력
+if [ "$JSON_OUTPUT" -eq 1 ]; then
+  cat "${VALID_FILES[@]}" \
+    | jq -c "${JQ_FILTER}" 2>/dev/null
+else
+  cat "${VALID_FILES[@]}" \
+    | jq -r "${JQ_FILTER} | \"\(.ts)  [\(.session | .[0:8])]  tags=[\(.tags)]  \(.cmd | .[0:120])\"" \
+    2>/dev/null
+fi
+
+exit 0

--- a/sync-manifest.json
+++ b/sync-manifest.json
@@ -34,7 +34,10 @@
     { "src": "templates/agent-teams/README.md",                   "dst": ".claude/agent-teams/README.md" },
     { "src": "templates/hooks/observability-push.sh",            "dst": ".claude/hooks/observability-push.sh" },
     { "src": "templates/observability/README.md",                "dst": ".claude/observability/README.md" },
-    { "src": "templates/observability/filter-rules.yaml",        "dst": ".claude/observability/filter-rules.yaml" }
+    { "src": "templates/observability/filter-rules.yaml",        "dst": ".claude/observability/filter-rules.yaml" },
+    { "src": "scripts/audit-grep.sh",                           "dst": "scripts/audit-grep.sh" },
+    { "src": "scripts/audit-analyze.py",                        "dst": "scripts/audit-analyze.py" },
+    { "src": "docs/audit-analysis.md",                          "dst": "docs/audit-analysis.md" }
   ],
   "computed": [
     { "generator": "merge-settings", "dst": ".claude/settings.json", "note": "base + type extension 병합 결과와 비교" }


### PR DESCRIPTION
## 무엇을 바꿨나

v8 backlog item 1.4 실현 — \`check-audit.sh\`가 축적하는 JSONL을 조회·분석하는 도구 2종.

- \`scripts/audit-grep.sh\` (229줄, jq 기반): 9 sub-options로 시간/툴/키워드/세션/빈도 필터링
- \`scripts/audit-analyze.py\` (338줄, 표준 라이브러리): 반복 실패 / 빈도 이상치 / 의심 패턴 3종 감지, 마크다운 리포트
- \`docs/audit-analysis.md\` (169줄, 한국어): 스키마 + 8 예시 + 워크플로우
- \`sync-manifest.json\`: 3 managed entries

## 왜 바꿨나

audit log는 쌓이는데 조회 도구가 없어 jq/grep 수동 파싱 필요했음. 재사용성 + 운영 이상행동 감지 자동화.

## 어떻게 검증했나

- [x] \`bash -n scripts/audit-grep.sh\` — 구문 통과
- [x] \`python3 -m py_compile scripts/audit-analyze.py\` — 통과
- [x] \`check-audit.sh\` JSONL 스키마 실제 파일에서 확인 (ts/session/matcher/tags/cmd — exit code 없음)
- [x] \`templates/hooks/check-audit.sh\` 무수정 (스키마 invariant)
- [x] 시크릿 0건
- [x] audit-analyze.py 외부 의존성 0건 (표준 라이브러리만)

## 제약

\`check-audit.sh\` 스키마에 exit code 필드가 없어 \`audit-analyze.py\`의 repeated-failure 감지는 "동일 cmd 반복 호출"로 근사. 정확한 실패 판정은 future work (check-audit.sh 스키마 확장).

## 다운스트림 영향

- [x] \`sync-manifest.json\` managed 등록 → 다음 sync 주기에 다운스트림 전파
- [x] 기존 \`.claude/audit/\` 로그 형식 유지 (후방 호환)

## 체크리스트

- [x] 한국어 원자적 커밋 (\`feat:\`)
- [x] 관련 Issue: #40
- [x] 구문 검증
- [x] 문서 동기화

Resolves #40